### PR TITLE
Implemented Training Class + Add methods for convenience to sampling routines  

### DIFF
--- a/qumcmc/basic_utils.py
+++ b/qumcmc/basic_utils.py
@@ -614,3 +614,5 @@ def get_cardinality_dataset(n_qubits, card=2):
 
     binary_strings = generate_binary_strings(n_qubits)
     return [b for b in binary_strings if b.count("1")==card]
+
+

--- a/qumcmc/basic_utils.py
+++ b/qumcmc/basic_utils.py
@@ -380,18 +380,6 @@ def int_to_str(state_obtained, nspin):
     return f"{state_obtained:0{nspin}b}"
 
 
-# def random_bstr(n,k=1):
-#     assert n >= k
-#     s = '1'*k + '0'*(n-k)
-#     perm = list(permutations(s))
-#     r = perm[np.random.randint(0, len(perm))]
-#     rnd_str = ''
-#     for i in r :
-#         rnd_str += i
-
-#     return rnd_str
-
-
 def random_bstr(n, k=1):
     assert n >= k
     s = "1" * k + "0" * (n - k)

--- a/qumcmc/classical_mcmc_routines.py
+++ b/qumcmc/classical_mcmc_routines.py
@@ -98,4 +98,5 @@ def classical_mcmc(
 
     return mcmc_chain
 
+
 ####

--- a/qumcmc/classical_mcmc_routines.py
+++ b/qumcmc/classical_mcmc_routines.py
@@ -13,6 +13,8 @@ from .classical_mixers import ClassicalMixer, UniformProposals
 
 from abc import ABC, abstractmethod
 from typing import List
+
+from dataclasses import dataclass
 ###########################################################################################
 ## CLASSICAL MCMC ROUTINES ##
 ###########################################################################################
@@ -104,6 +106,36 @@ def classical_mcmc(
             energy_s = model.get_energy(current_state.bitstring)
         
     return mcmc_chain
+
+####
+## decorator class for running classical_mcmc() 
+from .mcmc_sampler_base import mcmc_sampler
+@dataclass
+class clmcmc_sampler(mcmc_sampler) : 
+    
+    def __init__(self, 
+        n_hops: int ,
+        model: IsingEnergyFunction,
+        proposition_method: ClassicalMixer,
+        initial_state: Optional[str] = None,
+        temperature: float = 1,
+        verbose: bool = False,
+        name: str = "Cl-MCMC") -> None :  
+        
+        self.proposition_method = proposition_method
+        super().__init__(n_hops, model, initial_state, temperature, verbose, name)
+
+    def __repr__(self):
+        return f"Classical MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n PropositionType : {self.proposition_method} \n initial-state : {self.initial_state} \ntemp : {self.temperature}" 
+        # pass 
+    def run(self): 
+        return classical_mcmc(n_hops= self.n_hops ,
+                                     model= self.model , 
+                                     proposition_method= self.proposition_method ,
+                                     initial_state= self.initial_state , 
+                                     temperature= self.temperature ,                                      
+                                     verbose= self.verbose , 
+                                     name = self.name)
 
 # class ClassicalMixer(ABC):
     

--- a/qumcmc/classical_mcmc_routines.py
+++ b/qumcmc/classical_mcmc_routines.py
@@ -18,10 +18,8 @@ from .basic_utils import (
 )
 from .classical_mixers import ClassicalMixer, UniformProposals
 
-from abc import ABC, abstractmethod
 from typing import List
 
-from dataclasses import dataclass
 ###########################################################################################
 ## CLASSICAL MCMC ROUTINES ##
 ###########################################################################################
@@ -101,100 +99,3 @@ def classical_mcmc(
     return mcmc_chain
 
 ####
-## decorator class for running classical_mcmc() 
-from .mcmc_sampler_base import mcmc_sampler
-@dataclass
-class clmcmc_sampler(mcmc_sampler) : 
-    
-    def __init__(self, 
-        n_hops: int ,
-        model: IsingEnergyFunction,
-        proposition_method: ClassicalMixer,
-        initial_state: Optional[str] = None,
-        temperature: float = 1,
-        verbose: bool = False,
-        name: str = "Cl-MCMC") -> None :  
-        
-        self.proposition_method = proposition_method
-        super().__init__(n_hops, model, initial_state, temperature, verbose, name)
-
-    def __repr__(self):
-        return f"Classical MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n PropositionType : {self.proposition_method} \n initial-state : {self.initial_state} \ntemp : {self.temperature}" 
-        # pass 
-    def run(self): 
-        return classical_mcmc(n_hops= self.n_hops ,
-                                     model= self.model , 
-                                     proposition_method= self.proposition_method ,
-                                     initial_state= self.initial_state , 
-                                     temperature= self.temperature ,                                      
-                                     verbose= self.verbose , 
-                                     name = self.name)
-
-# class ClassicalMixer(ABC):
-    
-#     def __init__(self, num_spins: int) -> None:
-#         self.num_spins = num_spins
-#         # self.current_state = current_state
-#         self._precompute_properties()
-
-#     @abstractmethod
-#     def propose_transition(self): ...
-
-#     def _precompute_properties(self):
-#         pass
-
-# class UniformProposals(ClassicalMixer):
-
-#     def _init_(self, num_spins:int) -> None: 
-#         super().__init__(num_spins)
-
-#     def propose_transition(self):
-#         return get_random_state(self.num_spins)
-
-# class FixedWeightProposals(ClassicalMixer):
-
-#     def __init__(self, num_spins: int, bodyness: int, current_state: str ) -> None:
-#         self.bodyness = bodyness
-#         self.current_state = current_state
-
-#         assert self.bodyness <= self.num_spins , "Incorrect"
-        
-#         super().__init__(num_spins)
-        
-#     def propose_transition(self):
-#         rbstr = random_bstr(self.num_spins, self.bodyness)
-#         return xor_strings(self.current_state, rbstr)
-
-# class CustomProposals(ClassicalMixer):
-
-#     def __init__(self, num_spins: int, flip_pattern: List[int], current_state: str) -> None:
-#         self.flip_pattern =flip_pattern
-#         self.current_state = current_state
-#         super().__init__(num_spins)
-
-#     def propose_transition(self):
-#         rbstr = ''
-#         __ = [ '1' if i in self.flip_pattern else '0' for i in range(self.num_spins)]
-#         for _ in __ : rbstr += _ 
-#         return xor_strings(self.current_state, rbstr)
-    
-# class CombineProposals(ClassicalMixer):
-
-#     def __init__(self, proposal_methods: List[ClassicalMixer], probabilities: List[float], current_state: str) -> None:
-#         # super().__init__(num_spins) 
-#         self.num_spins = proposal_methods[0].num_spins
-#         assert all(
-#             self.num_spins == pm.num_spins for pm in proposal_methods
-#         ), "Mixers don't have the same number of qubits"
-#         assert len(probabilities) == len(
-#             proposal_methods
-#         ), "Length of list of mixers and probabilities is not equal" 
-
-#         self.probabilities = np.array(probabilities) / sum(probabilities)
-#         self.proposal_methods = proposal_methods
-#         self.current_state = current_state
-
-#         def propose_transition(self):
-#             proposal_method = np.random.choice(self.proposal_methods, p = self.probabilities)
-#             return proposal_method.propose_transition()
-#             # return 

--- a/qumcmc/classical_mixers.py
+++ b/qumcmc/classical_mixers.py
@@ -31,10 +31,12 @@ class UniformProposals(ClassicalMixer):
         num_spins: int,
     ) -> None:
         super().__init__(num_spins)
+
     def __repr__(self):
         return f"UniformProposals({self.num_spins})"
-    def propose_transition(self, current_state= None):
-        assert len(current_state) == self.num_spins , "Wrong 'current_state' "
+
+    def propose_transition(self, current_state=None):
+        assert len(current_state) == self.num_spins, "Wrong 'current_state' "
         return get_random_state(self.num_spins)
 
 
@@ -45,8 +47,10 @@ class FixedWeightProposals(ClassicalMixer):
         assert self.bodyness <= num_spins, "Incorrect"
 
         super().__init__(num_spins)
+
     def __repr__(self):
         return f"FixedWeightProposals({self.num_spins}, ({self.bodyness}))"
+
     def propose_transition(self, current_state: str):
         assert len(current_state) == self.num_spins, "Wrong 'current_state' "
         rbstr = random_bstr(self.num_spins, self.bodyness)
@@ -58,8 +62,10 @@ class CustomProposals(ClassicalMixer):
     def __init__(self, num_spins: int, flip_pattern: List[int]) -> None:
         self.flip_pattern = flip_pattern
         super().__init__(num_spins)
+
     def __repr__(self):
         return f"CustomProposals({self.num_spins}, pattern: {self.flip_pattern})"
+
     def propose_transition(self, current_state: str):
         assert len(current_state) == self.num_spins, "Wrong 'current_state' "
         rbstr = ""
@@ -85,8 +91,10 @@ class CombineProposals(ClassicalMixer):
 
         self.probabilities = np.array(probabilities) / sum(probabilities)
         self.proposal_methods = proposal_methods
+
     def __repr__(self):
         return f"CombinedProposals( num-proposal-methods = {len(self.proposal_methods)} , p = {self.probabilities})"
+
     def propose_transition(self, current_state: str):
         assert len(current_state) == self.num_spins, "Wrong 'current_state' "
         proposal_method = np.random.choice(self.proposal_methods, p=self.probabilities)

--- a/qumcmc/classical_mixers.py
+++ b/qumcmc/classical_mixers.py
@@ -24,7 +24,8 @@ class UniformProposals(ClassicalMixer):
 
     def _init_(self, num_spins:int, ) -> None: 
         super().__init__(num_spins)
-
+    def __repr__(self):
+        return f"UniformProposals({self.num_spins})"
     def propose_transition(self, current_state= None):
         assert len(current_state) == self.num_spins , "Wrong 'current_state' "
         return get_random_state(self.num_spins)
@@ -36,7 +37,8 @@ class FixedWeightProposals(ClassicalMixer):
         assert self.bodyness <= num_spins , "Incorrect"
         
         super().__init__(num_spins)
-        
+    def __repr__(self):
+        return f"FixedWeightProposals({self.num_spins}, ({self.bodyness}))"
     def propose_transition(self, current_state: str):
         assert len(current_state) == self.num_spins , "Wrong 'current_state' "
         rbstr = random_bstr(self.num_spins, self.bodyness)
@@ -47,7 +49,8 @@ class CustomProposals(ClassicalMixer):
     def __init__(self, num_spins: int, flip_pattern: List[int]) -> None:
         self.flip_pattern =flip_pattern
         super().__init__(num_spins)
-
+    def __repr__(self):
+        return f"CustomProposals({self.num_spins}, pattern: {self.flip_pattern})"
     def propose_transition(self, current_state: str):
         assert len(current_state) == self.num_spins , "Wrong 'current_state' "
         rbstr = ''
@@ -69,7 +72,8 @@ class CombineProposals(ClassicalMixer):
 
         self.probabilities = np.array(probabilities) / sum(probabilities)
         self.proposal_methods = proposal_methods
-
+    def __repr__(self):
+        return f"CombinedProposals( num-proposal-methods = {len(self.proposal_methods)} , p = {self.probabilities})"
     def propose_transition(self, current_state: str):
             assert len(current_state) == self.num_spins , "Wrong 'current_state' "
             proposal_method = np.random.choice(self.proposal_methods, p = self.probabilities)

--- a/qumcmc/energy_models.py
+++ b/qumcmc/energy_models.py
@@ -51,9 +51,9 @@ class IsingEnergyFunction:
         else:
             self.name = name
 
-    def __repr__(self) : 
+    def __repr__(self):
         return f"Ising Model:{self.name}| num-spins: {self.num_spins}"
-    
+
     @property
     def get_J(self):
         return self.J

--- a/qumcmc/energy_models.py
+++ b/qumcmc/energy_models.py
@@ -51,6 +51,9 @@ class IsingEnergyFunction:
         else:
             self.name = name
 
+    def __repr__(self) : 
+        return f"Ising Model:{self.name}| num-spins: {self.num_spins}"
+    
     @property
     def get_J(self):
         return self.J

--- a/qumcmc/mcmc_sampler_base.py
+++ b/qumcmc/mcmc_sampler_base.py
@@ -1,0 +1,33 @@
+###################
+# from dataclasses import dataclass 
+from .energy_models import IsingEnergyFunction
+from typing import Optional
+from abc import ABC, abstractmethod, abstractproperty
+
+###################
+# @dataclass
+class mcmc_sampler(ABC) :
+
+    def __init__(self,
+        n_hops: int ,
+        model : IsingEnergyFunction, 
+        initial_state : Optional[str] = None,
+        temperature : float  = 1.0 ,
+        verbose: bool = False ,
+        name : str = "MCMC" ) -> None : 
+
+        self.n_hops= n_hops 
+        self.model= model 
+        self.initial_state = initial_state 
+        self.temperature = temperature
+        self.verbose = verbose
+        self.name = name 
+        
+    def __repr__(self): 
+        return f" MCMCSampler:{self.name}| model:{self.model}"
+    
+    @abstractmethod
+    def run(self): ... 
+
+    
+

--- a/qumcmc/mcmc_sampler_base.py
+++ b/qumcmc/mcmc_sampler_base.py
@@ -4,9 +4,11 @@ from .energy_models import IsingEnergyFunction
 from typing import Optional
 from abc import ABC, abstractmethod, abstractproperty
 
+from dataclasses import dataclass
+
 ###################
 # @dataclass
-class mcmc_sampler(ABC) :
+class MCMCSampler(ABC) :
 
     def __init__(self,
         n_hops: int ,
@@ -31,3 +33,68 @@ class mcmc_sampler(ABC) :
 
     
 
+## wrapper class for running classical_mcmc() 
+from .mcmc_sampler_base import MCMCSampler
+@dataclass
+class ClassicalMCMCSampler(MCMCSampler) : 
+    
+    def __init__(self, 
+        n_hops: int ,
+        model: IsingEnergyFunction,
+        proposition_method: ClassicalMixer,
+        initial_state: Optional[str] = None,
+        temperature: float = 1,
+        verbose: bool = False,
+        name: str = "Cl-MCMC") -> None :  
+        
+        self.proposition_method = proposition_method
+        super().__init__(n_hops, model, initial_state, temperature, verbose, name)
+
+    def __repr__(self):
+        return f"Classical MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n PropositionType : {self.proposition_method} \n initial-state : {self.initial_state} \ntemp : {self.temperature}" 
+        # pass 
+    def run(self): 
+        return classical_mcmc(n_hops= self.n_hops ,
+                                     model= self.model , 
+                                     proposition_method= self.proposition_method ,
+                                     initial_state= self.initial_state , 
+                                     temperature= self.temperature ,                                      
+                                     verbose= self.verbose , 
+                                     name = self.name)
+
+## wrapper class for running quantum_enhanced_mcmc() 
+
+from .mcmc_sampler_base import MCMCSampler
+@dataclass
+class QuantumMCMCSampler(MCMCSampler) : 
+
+    def __init__(self,
+        n_hops: int ,
+        model: IsingEnergyFunction,
+        mixer: Mixer,
+        gamma: GammaType,
+        initial_state: Optional[str] = None,
+        temperature: float = 1,
+        delta_time=0.8,
+        verbose: bool = False,
+        name: str = "Q-MCMC") -> None : 
+        
+        self.mixer = mixer 
+        self.gamma = gamma 
+        self.delta_time = delta_time
+        super().__init__(n_hops, model, initial_state, temperature, verbose, name)
+
+    # super.__init__(n_hops, model, initial_state, temperature, verbose, name)
+    def __repr__(self):
+        return f"Quantum MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n Mixer : {self.mixer} \n initial-state : {self.initial_state} \ngamma : {self.gamma} | temp : {self.temperature} | evolution-time : {self.delta_time}\n  " 
+        # pass 
+    def run(self): 
+        return quantum_enhanced_mcmc(n_hops= self.n_hops ,
+                                     model= self.model , 
+                                     mixer = self.mixer , 
+                                     gamma= self.gamma ,
+                                     initial_state= self.initial_state , 
+                                     temperature= self.temperature , 
+                                     delta_time= self.delta_time , 
+                                     verbose= self.verbose , 
+                                     name = self.name)

--- a/qumcmc/mcmc_sampler_base.py
+++ b/qumcmc/mcmc_sampler_base.py
@@ -71,7 +71,7 @@ class QuantumMCMCSampler(MCMCSampler) :
         n_hops: int ,
         model: IsingEnergyFunction,
         mixer: Mixer,
-        gamma: GammaType,
+        gamma: float,
         initial_state: Optional[str] = None,
         temperature: float = 1,
         delta_time=0.8,

--- a/qumcmc/mcmc_sampler_base.py
+++ b/qumcmc/mcmc_sampler_base.py
@@ -1,11 +1,14 @@
 ###################
 # from dataclasses import dataclass 
 from .energy_models import IsingEnergyFunction
-from typing import Optional
-from abc import ABC, abstractmethod, abstractproperty
+from .classical_mixers import ClassicalMixer
+from .mixers import Mixer 
+from .classical_mcmc_routines import classical_mcmc
+from .quantum_mcmc_routines import quantum_enhanced_mcmc 
 
 from dataclasses import dataclass
-
+from typing import Optional
+from abc import ABC, abstractmethod, abstractproperty
 ###################
 # @dataclass
 class MCMCSampler(ABC) :
@@ -34,8 +37,6 @@ class MCMCSampler(ABC) :
     
 
 ## wrapper class for running classical_mcmc() 
-from .mcmc_sampler_base import MCMCSampler
-@dataclass
 class ClassicalMCMCSampler(MCMCSampler) : 
     
     def __init__(self, 
@@ -64,8 +65,6 @@ class ClassicalMCMCSampler(MCMCSampler) :
 
 ## wrapper class for running quantum_enhanced_mcmc() 
 
-from .mcmc_sampler_base import MCMCSampler
-@dataclass
 class QuantumMCMCSampler(MCMCSampler) : 
 
     def __init__(self,

--- a/qumcmc/mcmc_sampler_base.py
+++ b/qumcmc/mcmc_sampler_base.py
@@ -1,74 +1,85 @@
 ###################
-# from dataclasses import dataclass 
+# from dataclasses import dataclass
 from .energy_models import IsingEnergyFunction
 from .classical_mixers import ClassicalMixer
-from .mixers import Mixer 
+from .mixers import Mixer
 from .classical_mcmc_routines import classical_mcmc
-from .quantum_mcmc_routines import quantum_enhanced_mcmc 
+from .quantum_mcmc_routines import quantum_enhanced_mcmc
 
 from dataclasses import dataclass
 from typing import Optional
 from abc import ABC, abstractmethod, abstractproperty
+
+
 ###################
 # @dataclass
-class MCMCSampler(ABC) :
+class MCMCSampler(ABC):
 
-    def __init__(self,
-        n_hops: int ,
-        model : IsingEnergyFunction, 
-        initial_state : Optional[str] = None,
-        temperature : float  = 1.0 ,
-        verbose: bool = False ,
-        name : str = "MCMC" ) -> None : 
+    def __init__(
+        self,
+        n_hops: int,
+        model: IsingEnergyFunction,
+        initial_state: Optional[str] = None,
+        temperature: float = 1.0,
+        verbose: bool = False,
+        name: str = "MCMC",
+    ) -> None:
 
-        self.n_hops= n_hops 
-        self.model= model 
-        self.initial_state = initial_state 
+        self.n_hops = n_hops
+        self.model = model
+        self.initial_state = initial_state
         self.temperature = temperature
         self.verbose = verbose
-        self.name = name 
-        
-    def __repr__(self): 
+        self.name = name
+
+    def __repr__(self):
         return f" MCMCSampler:{self.name}| model:{self.model}"
-    
+
     @abstractmethod
-    def run(self): ... 
+    def run(self): ...
 
-    
 
-## wrapper class for running classical_mcmc() 
-class ClassicalMCMCSampler(MCMCSampler) : 
-    
-    def __init__(self, 
-        n_hops: int ,
+## wrapper class for running classical_mcmc()
+class ClassicalMCMCSampler(MCMCSampler):
+
+    def __init__(
+        self,
+        n_hops: int,
         model: IsingEnergyFunction,
         proposition_method: ClassicalMixer,
         initial_state: Optional[str] = None,
         temperature: float = 1,
         verbose: bool = False,
-        name: str = "Cl-MCMC") -> None :  
-        
+        name: str = "Cl-MCMC",
+    ) -> None:
+
         self.proposition_method = proposition_method
         super().__init__(n_hops, model, initial_state, temperature, verbose, name)
 
     def __repr__(self):
-        return f"Classical MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n PropositionType : {self.proposition_method} \n initial-state : {self.initial_state} \ntemp : {self.temperature}" 
-        # pass 
-    def run(self): 
-        return classical_mcmc(n_hops= self.n_hops ,
-                                     model= self.model , 
-                                     proposition_method= self.proposition_method ,
-                                     initial_state= self.initial_state , 
-                                     temperature= self.temperature ,                                      
-                                     verbose= self.verbose , 
-                                     name = self.name)
+        return f"Classical MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n PropositionType : {self.proposition_method} \n initial-state : {self.initial_state} \ntemp : {self.temperature}"
+        # pass
 
-## wrapper class for running quantum_enhanced_mcmc() 
+    def run(self):
+        return classical_mcmc(
+            n_hops=self.n_hops,
+            model=self.model,
+            proposition_method=self.proposition_method,
+            initial_state=self.initial_state,
+            temperature=self.temperature,
+            verbose=self.verbose,
+            name=self.name,
+        )
 
-class QuantumMCMCSampler(MCMCSampler) : 
 
-    def __init__(self,
-        n_hops: int ,
+## wrapper class for running quantum_enhanced_mcmc()
+
+
+class QuantumMCMCSampler(MCMCSampler):
+
+    def __init__(
+        self,
+        n_hops: int,
         model: IsingEnergyFunction,
         mixer: Mixer,
         gamma: float,
@@ -76,24 +87,28 @@ class QuantumMCMCSampler(MCMCSampler) :
         temperature: float = 1,
         delta_time=0.8,
         verbose: bool = False,
-        name: str = "Q-MCMC") -> None : 
-        
-        self.mixer = mixer 
-        self.gamma = gamma 
+        name: str = "Q-MCMC",
+    ) -> None:
+
+        self.mixer = mixer
+        self.gamma = gamma
         self.delta_time = delta_time
         super().__init__(n_hops, model, initial_state, temperature, verbose, name)
 
     # super.__init__(n_hops, model, initial_state, temperature, verbose, name)
     def __repr__(self):
-        return f"Quantum MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n Mixer : {self.mixer} \n initial-state : {self.initial_state} \ngamma : {self.gamma} | temp : {self.temperature} | evolution-time : {self.delta_time}\n  " 
-        # pass 
-    def run(self): 
-        return quantum_enhanced_mcmc(n_hops= self.n_hops ,
-                                     model= self.model , 
-                                     mixer = self.mixer , 
-                                     gamma= self.gamma ,
-                                     initial_state= self.initial_state , 
-                                     temperature= self.temperature , 
-                                     delta_time= self.delta_time , 
-                                     verbose= self.verbose , 
-                                     name = self.name)
+        return f"Quantum MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n Mixer : {self.mixer} \n initial-state : {self.initial_state} \ngamma : {self.gamma} | temp : {self.temperature} | evolution-time : {self.delta_time}\n  "
+        # pass
+
+    def run(self):
+        return quantum_enhanced_mcmc(
+            n_hops=self.n_hops,
+            model=self.model,
+            mixer=self.mixer,
+            gamma=self.gamma,
+            initial_state=self.initial_state,
+            temperature=self.temperature,
+            delta_time=self.delta_time,
+            verbose=self.verbose,
+            name=self.name,
+        )

--- a/qumcmc/mixers.py
+++ b/qumcmc/mixers.py
@@ -28,9 +28,9 @@ class GenericMixer(Mixer):
         self.bodyness = bodyness
         super().__init__(n_qubits)
 
-    def __repr__(self): 
+    def __repr__(self):
         return f" GenericMixer : \n ------------- \n num-qubits = {self.n_qubits } | bodyness = {self.bodyness}"
-    
+
     def get_mixer_circuit(self, gamma: float, delta_time: float):
 
         qc_evolution_under_mixer = QuantumCircuit(self.n_qubits)
@@ -82,10 +82,9 @@ class CustomMixer(Mixer):
         self.possible_qubit_combinations = possible_qubit_combinations
 
         self._precompute_properties()
-  
-    def __repr__(self): 
+
+    def __repr__(self):
         return f" GenericMixer : \n ------------- \n num-qubits = {self.n_qubits } \n -------- \n possible-qubit-combintations = {self.possible_qubit_combinations}"
-    
 
     def get_mixer_circuit(self, gamma, delta_time):
 
@@ -118,8 +117,10 @@ class CoherentMixerSum(Mixer):
         ), "Length of list of mixers and weights is not equal"
         self.mixers = mixers
         self.weights = np.array(weights) / sum(weights)
-    def __repr__(self): 
+
+    def __repr__(self):
         return f"CoherentMixerSum -> num_mixers : {len(self.mixers)} |  weights : {self.weights}"
+
     def get_mixer_circuit(self, gamma: float, delta_time: float):
         total_circuit = QuantumCircuit(self.n_qubits)
         for weight, mixer in zip(self.weights, self.mixers):
@@ -141,8 +142,10 @@ class IncoherentMixerSum(Mixer):
         ), "Length of list of mixers and probabilities is not equal"
         self.mixers = mixers
         self.probabilities = np.array(probabilities) / sum(probabilities)
-    def __repr__(self): 
+
+    def __repr__(self):
         return f"IncoherentMixerSum -> num_mixers : {len(self.mixers)} |  probabilities : {self.probabilities}"
+
     def get_mixer_circuit(self, gamma: float, delta_time: float):
         mixer = np.random.choice(self.mixers, p=self.probabilities)
         return mixer.get_mixer_circuit(gamma, delta_time)

--- a/qumcmc/mixers.py
+++ b/qumcmc/mixers.py
@@ -28,6 +28,9 @@ class GenericMixer(Mixer):
         self.bodyness = bodyness
         super().__init__(n_qubits)
 
+    def __repr__(self): 
+        return f" GenericMixer : \n ------------- \n num-qubits = {self.n_qubits } | bodyness = {self.bodyness}"
+    
     def get_mixer_circuit(self, gamma: float, delta_time: float):
 
         qc_evolution_under_mixer = QuantumCircuit(self.n_qubits)
@@ -79,6 +82,10 @@ class CustomMixer(Mixer):
         self.possible_qubit_combinations = possible_qubit_combinations
 
         self._precompute_properties()
+  
+    def __repr__(self): 
+        return f" GenericMixer : \n ------------- \n num-qubits = {self.n_qubits } \n -------- \n possible-qubit-combintations = {self.possible_qubit_combinations}"
+    
 
     def get_mixer_circuit(self, gamma, delta_time):
 
@@ -111,7 +118,8 @@ class CoherentMixerSum(Mixer):
         ), "Length of list of mixers and weights is not equal"
         self.mixers = mixers
         self.weights = np.array(weights) / sum(weights)
-
+    def __repr__(self): 
+        return f"CoherentMixerSum -> num_mixers : {len(self.mixers)} |  weights : {self.weights}"
     def get_mixer_circuit(self, gamma: float, delta_time: float):
         total_circuit = QuantumCircuit(self.n_qubits)
         for weight, mixer in zip(self.weights, self.mixers):
@@ -133,7 +141,8 @@ class IncoherentMixerSum(Mixer):
         ), "Length of list of mixers and probabilities is not equal"
         self.mixers = mixers
         self.probabilities = np.array(probabilities) / sum(probabilities)
-
+    def __repr__(self): 
+        return f"IncoherentMixerSum -> num_mixers : {len(self.mixers)} |  probabilities : {self.probabilities}"
     def get_mixer_circuit(self, gamma: float, delta_time: float):
         mixer = np.random.choice(self.mixers, p=self.probabilities)
         return mixer.get_mixer_circuit(gamma, delta_time)

--- a/qumcmc/prob_dist.py
+++ b/qumcmc/prob_dist.py
@@ -4,59 +4,66 @@
 
 from .basic_utils import *
 from typing import Dict
+
 EPS = 1e-8
 
+
 class DiscreteProbabilityDistribution(dict):
-    """ A class for handling discrete probability distributions """
+    """A class for handling discrete probability distributions"""
 
-    def __init__(self, distribution:dict) -> None :
+    def __init__(self, distribution: dict) -> None:
 
-        super().__init__(distribution) 
-        
-        if sum(list(distribution.values())) != 1.0 : 
+        super().__init__(distribution)
+
+        if sum(list(distribution.values())) != 1.0:
             self._normalise()
-    
-    def _normalise(self, print_normalisation:bool= False):
-        """ Normalise the given disribution 
-            NOTE: works inplace 
+
+    def _normalise(self, print_normalisation: bool = False):
+        """Normalise the given disribution
+        NOTE: works inplace
         """
-        
+
         r_sum = np.sum(list(self.values()))
-        if print_normalisation : print('Normalisation : ', r_sum)
-        for k in list(self.keys()) :
+        if print_normalisation:
+            print("Normalisation : ", r_sum)
+        for k in list(self.keys()):
             self[k] = self[k] / r_sum
 
     def value_sorted_dict(self, reverse=False):
-        """ Sort the dictionary in ascending or descending(if reverse=True) order of values. """
+        """Sort the dictionary in ascending or descending(if reverse=True) order of values."""
         sorted_dict = {
             k: v
             for k, v in sorted(self.items(), key=lambda item: item[1], reverse=reverse)
         }
         return sorted_dict
 
-    def index_sorted_dict(self, reverse= False):
-        """ Sort the dictionary in ascending or descending(if reverse=True) order of index. """
+    def index_sorted_dict(self, reverse=False):
+        """Sort the dictionary in ascending or descending(if reverse=True) order of index."""
         sorted_dict = {
             k: v
             for k, v in sorted(self.items(), key=lambda item: item[0], reverse=reverse)
         }
         return sorted_dict
-   
-    def get_truncated_distribution(self, epsilon:float = 0.00001, inplace:bool = False):
-        
+
+    def get_truncated_distribution(
+        self, epsilon: float = 0.00001, inplace: bool = False
+    ):
+
         return_dict = {}
-        index_probable_elements = [ indx for indx, b in enumerate( np.array(list(self.values())) > epsilon ) if b ]
+        index_probable_elements = [
+            indx for indx, b in enumerate(np.array(list(self.values())) > epsilon) if b
+        ]
         states = list(self.keys())
         probs = list(self.values())
 
         for indx in index_probable_elements:
             return_dict[states[indx]] = probs[indx]
-        
+
         if not inplace:
             return DiscreteProbabilityDistribution(return_dict)
-        else :
+        else:
             self.__init__(return_dict)
-            
+
     def expectation(self, dict_observable_val_at_states: dict):
         """
         new version:
@@ -69,11 +76,10 @@ class DiscreteProbabilityDistribution(dict):
         Returns:
         avg
         """
-        ##TODO: A faster implementation is possible by using numpy 
+        ##TODO: A faster implementation is possible by using numpy
         len_dict = len(self)
         temp_list = [
-            self[j] * dict_observable_val_at_states[j]
-            for j in (list(self.keys()))
+            self[j] * dict_observable_val_at_states[j] for j in (list(self.keys()))
         ]
         avg = np.sum(
             temp_list
@@ -81,52 +87,48 @@ class DiscreteProbabilityDistribution(dict):
         return avg
 
     def get_entropy(self):
-        tmp = sorted(np.array(list(self.values())), reverse= True)
+        tmp = sorted(np.array(list(self.values())), reverse=True)
         entropy = 0
-        for val in tmp :
-            if val > 0.00001 :
+        for val in tmp:
+            if val > 0.00001:
                 entropy += -1 * val * np.log2(val)
-            else: 
+            else:
                 return entropy
-    
-    def get_observable_expectation(self, observable) -> float:
-        """ Return expectation value of a classical observables
 
-            ARGS :
-            ----
-            observable: Must be a function of the spin configuration which takes an 'np.array' / 'str' of binary elements as input argument and returns a 'float'
-            beta: inverse temperature
+    def get_observable_expectation(self, observable) -> float:
+        """Return expectation value of a classical observables
+
+        ARGS :
+        ----
+        observable: Must be a function of the spin configuration which takes an 'np.array' / 'str' of binary elements as input argument and returns a 'float'
+        beta: inverse temperature
 
         """
         # all_configs = np.array(list(itertools.product([1, 0], repeat=self.num_spins)))
         # all_configs = [f"{k:0{self.num_spins}b}" for k in range(0, 2 ** (self.num_spins))]
-        
 
-        return np.sum(
-            [
-                self[config]
-                * observable(config)
+        return np.sum([self[config] * observable(config) for config in self.keys()])
 
-                for config in self.keys()
-            ]
-        )         
+    def get_sample(self, num_samples, seed: int = np.random.randint(1, 10000)) -> list:
+        """Generate random samples from the distribution
 
-    def get_sample(self, num_samples, seed:int = np.random.randint(1,10000)) -> list:
-        """ Generate random samples from the distribution 
-        
-            ARGS
-            ----
-            num_smaples: no. of samples
+        ARGS
+        ----
+        num_smaples: no. of samples
         """
         # np.random.seed(seed)
-        return list(np.random.choice(list(self.keys()),p= list(self.values()), size= num_samples))
-        
-### SOME FUNCTIONS.
-#1. KL divergence
-#2. JS divergence
+        return list(
+            np.random.choice(list(self.keys()), p=list(self.values()), size=num_samples)
+        )
 
-def kl_divergence(dict_p: dict, dict_q: dict, prelim_check: bool= False):
-    ''' 
+
+### SOME FUNCTIONS.
+# 1. KL divergence
+# 2. JS divergence
+
+
+def kl_divergence(dict_p: dict, dict_q: dict, prelim_check: bool = False):
+    """
     Returns KL divergence KL(p||q);
 
     Args:
@@ -135,17 +137,15 @@ def kl_divergence(dict_p: dict, dict_q: dict, prelim_check: bool= False):
 
     dict_q: distribution q ({random_variable: prob}),
 
-    prelim_check: default 'True'. 
-    If user is completely sure that 
+    prelim_check: default 'True'.
+    If user is completely sure that
     dict_p and dict_q have same keys and that both the distributions are
     normalised then user can set it to 'False'.
-    '''
+    """
     KL = 0
     for bitstring, p_data in dict_p.items():
         if bitstring in dict_q.keys():
-            KL += p_data * np.log(p_data) - p_data * np.log(
-                max(EPS, dict_q[bitstring])
-            )
+            KL += p_data * np.log(p_data) - p_data * np.log(max(EPS, dict_q[bitstring]))
         else:
             KL += p_data * np.log(p_data) - p_data * np.log(EPS)
     return KL
@@ -156,49 +156,56 @@ def vectoried_KL(target_vector, model_vector):
     target_vector = target_vector[inds]
     model_vector = model_vector[inds]
     model_vector = np.where(model_vector < EPS, EPS, model_vector)
-    return np.sum(target_vector * np.log(target_vector) - target_vector*np.log(model_vector))
+    return np.sum(
+        target_vector * np.log(target_vector) - target_vector * np.log(model_vector)
+    )
 
 
-def js_divergence(dict_p:dict,dict_q:dict, prelim_check=True):
-    ''' 
+def js_divergence(dict_p: dict, dict_q: dict, prelim_check=True):
+    """
     Returns JS divergence JS(p||q);
-    
+
     Args:
     dict_p: distribution p ({random_variable: prob}),
 
     dict_q: distribution q ({random_variable: prob}),
 
-    prelim_check: default 'True'. 
-    If user is completely sure that 
+    prelim_check: default 'True'.
+    If user is completely sure that
     dict_p and dict_q have same keys and that both the distributions are
     normalised then user can set it to 'False'.
-    '''
+    """
     if prelim_check:
-        #check for whether or not dict_p and dict_q have same keys
-        keys_p,keys_q=list(dict_p.keys()),list(dict_q.keys())
-        keys_p.sort();keys_q.sort()
-        if keys_p==keys_q: pass  #"keys of both the dictionaries dont match!"
-        else :
-            for key in set(dict_p.keys()).union(set(dict_q.keys())) :
-                if key not in dict_p.keys(): dict_p[key] = 0.0
-                if key not in dict_q.keys(): dict_q[key] = 0.0
+        # check for whether or not dict_p and dict_q have same keys
+        keys_p, keys_q = list(dict_p.keys()), list(dict_q.keys())
+        keys_p.sort()
+        keys_q.sort()
+        if keys_p == keys_q:
+            pass  # "keys of both the dictionaries dont match!"
+        else:
+            for key in set(dict_p.keys()).union(set(dict_q.keys())):
+                if key not in dict_p.keys():
+                    dict_p[key] = 0.0
+                if key not in dict_q.keys():
+                    dict_q[key] = 0.0
 
         # print('p: ', dict_p)
         # print('q: ', dict_q)
         # check for whether values add to 1.
-        eps=1e-6
-        sum_vals_p=np.sum(list(dict_p.values()))
-        assert np.abs(sum_vals_p-1.0)<=eps, "sum of values of dict_p must be 1."
-        sum_vals_q=np.sum(list(dict_q.values()))
-        assert np.abs(sum_vals_q-1.0)<=eps, "sum of values of dict_q must be 1."
+        eps = 1e-6
+        sum_vals_p = np.sum(list(dict_p.values()))
+        assert np.abs(sum_vals_p - 1.0) <= eps, "sum of values of dict_p must be 1."
+        sum_vals_q = np.sum(list(dict_q.values()))
+        assert np.abs(sum_vals_q - 1.0) <= eps, "sum of values of dict_q must be 1."
 
-
-    #prep for caln
-    p=DiscreteProbabilityDistribution(dict_p).index_sorted_dict()
-    q=DiscreteProbabilityDistribution(dict_q).index_sorted_dict()
-    p_arr,q_arr=np.array(list(p.values())).reshape((len(p))), np.array(list(q.values())).reshape((len(q)))
-    val_m = np.round(0.5 * (p_arr + q_arr),decimals=12)
-    #print("val_m:");print(val_m)
-    m=dict(zip(list(p.keys()),val_m))
-    #print("m:");print(m)
-    return 0.5 * (kl_divergence(p, m) +  kl_divergence(q, m ))
+    # prep for caln
+    p = DiscreteProbabilityDistribution(dict_p).index_sorted_dict()
+    q = DiscreteProbabilityDistribution(dict_q).index_sorted_dict()
+    p_arr, q_arr = np.array(list(p.values())).reshape((len(p))), np.array(
+        list(q.values())
+    ).reshape((len(q)))
+    val_m = np.round(0.5 * (p_arr + q_arr), decimals=12)
+    # print("val_m:");print(val_m)
+    m = dict(zip(list(p.keys()), val_m))
+    # print("m:");print(m)
+    return 0.5 * (kl_divergence(p, m) + kl_divergence(q, m))

--- a/qumcmc/quantum_mcmc_routines.py
+++ b/qumcmc/quantum_mcmc_routines.py
@@ -226,4 +226,5 @@ def quantum_enhanced_mcmc(
 
     return mcmc_chain
 
+
 ####

--- a/qumcmc/quantum_mcmc_routines.py
+++ b/qumcmc/quantum_mcmc_routines.py
@@ -227,39 +227,3 @@ def quantum_enhanced_mcmc(
     return mcmc_chain
 
 ####
-## decorator class for running quantum_enhanced_mcmc() 
-from dataclasses import dataclass
-from .mcmc_sampler_base import mcmc_sampler
-@dataclass
-class qumcmc_sampler(mcmc_sampler) : 
-
-    def __init__(self,
-        n_hops: int ,
-        model: IsingEnergyFunction,
-        mixer: Mixer,
-        gamma: GammaType,
-        initial_state: Optional[str] = None,
-        temperature: float = 1,
-        delta_time=0.8,
-        verbose: bool = False,
-        name: str = "Q-MCMC") -> None : 
-        
-        self.mixer = mixer 
-        self.gamma = gamma 
-        self.delta_time = delta_time
-        super().__init__(n_hops, model, initial_state, temperature, verbose, name)
-
-    # super.__init__(n_hops, model, initial_state, temperature, verbose, name)
-    def __repr__(self):
-        return f"Quantum MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n Mixer : {self.mixer} \n initial-state : {self.initial_state} \ngamma : {self.gamma} | temp : {self.temperature} | evolution-time : {self.delta_time}\n  " 
-        # pass 
-    def run(self): 
-        return quantum_enhanced_mcmc(n_hops= self.n_hops ,
-                                     model= self.model , 
-                                     mixer = self.mixer , 
-                                     gamma= self.gamma ,
-                                     initial_state= self.initial_state , 
-                                     temperature= self.temperature , 
-                                     delta_time= self.delta_time , 
-                                     verbose= self.verbose , 
-                                     name = self.name)

--- a/qumcmc/quantum_mcmc_routines.py
+++ b/qumcmc/quantum_mcmc_routines.py
@@ -225,3 +225,41 @@ def quantum_enhanced_mcmc(
             pass
 
     return mcmc_chain
+
+####
+## decorator class for running quantum_enhanced_mcmc() 
+from dataclasses import dataclass
+from .mcmc_sampler_base import mcmc_sampler
+@dataclass
+class qumcmc_sampler(mcmc_sampler) : 
+
+    def __init__(self,
+        n_hops: int ,
+        model: IsingEnergyFunction,
+        mixer: Mixer,
+        gamma: GammaType,
+        initial_state: Optional[str] = None,
+        temperature: float = 1,
+        delta_time=0.8,
+        verbose: bool = False,
+        name: str = "Q-MCMC") -> None : 
+        
+        self.mixer = mixer 
+        self.gamma = gamma 
+        self.delta_time = delta_time
+        super().__init__(n_hops, model, initial_state, temperature, verbose, name)
+
+    # super.__init__(n_hops, model, initial_state, temperature, verbose, name)
+    def __repr__(self):
+        return f"Quantum MCMCSampler: {self.name} \n ------------------- Iterations : {self.n_hops} \n Model : {self.model} \n Mixer : {self.mixer} \n initial-state : {self.initial_state} \ngamma : {self.gamma} | temp : {self.temperature} | evolution-time : {self.delta_time}\n  " 
+        # pass 
+    def run(self): 
+        return quantum_enhanced_mcmc(n_hops= self.n_hops ,
+                                     model= self.model , 
+                                     mixer = self.mixer , 
+                                     gamma= self.gamma ,
+                                     initial_state= self.initial_state , 
+                                     temperature= self.temperature , 
+                                     delta_time= self.delta_time , 
+                                     verbose= self.verbose , 
+                                     name = self.name)

--- a/qumcmc/quantum_mcmc_routines_exact.py
+++ b/qumcmc/quantum_mcmc_routines_exact.py
@@ -5,10 +5,12 @@ import numpy as np
 from typing import Optional
 from tqdm import tqdm
 from collections import Counter
-from .basic_utils import  states, MCMCChain, MCMCState
+from .basic_utils import states, MCMCChain, MCMCState
+
 # from .prob_dist import *
 from .energy_models import IsingEnergyFunction
 from .classical_mcmc_routines import test_accept, get_random_state
+
 # from qiskit import (
 #     QuantumCircuit,
 #     QuantumRegister,
@@ -22,9 +24,10 @@ from qulacs import QuantumState, QuantumCircuit
 from qulacs import Observable
 from qulacsvis import circuit_drawer
 from scipy.linalg import expm
-#from scipy.sparse.linalg import expm
+
+# from scipy.sparse.linalg import expm
 from qulacs.gate import DenseMatrix, SparseMatrix
-from qulacs.gate import X, Y, Z  , Pauli, Identity, merge
+from qulacs.gate import X, Y, Z, Pauli, Identity, merge
 
 from itertools import combinations
 import random
@@ -33,52 +36,61 @@ import random
 ##  QUANTUM MARKOV CHAIN CONSTRUCTION ##
 ################################################################################################
 
+
 # function for U=exp(-iHt) (a unitary evolution)
 # H =(1-gamma)*alpha*H_{prob} + gamma * H_mix
-def time_evolution(num_spins:int, hamiltonian:np.array,
-                        current_q_state:QuantumState, 
-                        time_evol:float):
-    '''
+def time_evolution(
+    num_spins: int,
+    hamiltonian: np.array,
+    current_q_state: QuantumState,
+    time_evol: float,
+):
+    """
     Exact unitary time evolution under the hamiltonian H
-    Question: 
-    1.  What should be the type of input q_state? 
+    Question:
+    1.  What should be the type of input q_state?
     2. Should I return a QuantumState object or a simple computational bitstring?
-    '''
-    #target_list=list(range(num_spins-1,-1,-1))
-    target_list=list(range(0,num_spins))
-    unitary_mat= np.round(expm(-1j*hamiltonian*time_evol),decimals=6)
-    unitary_time_evol_gate=DenseMatrix(target_list,matrix=unitary_mat)
+    """
+    # target_list=list(range(num_spins-1,-1,-1))
+    target_list = list(range(0, num_spins))
+    unitary_mat = np.round(expm(-1j * hamiltonian * time_evol), decimals=6)
+    unitary_time_evol_gate = DenseMatrix(target_list, matrix=unitary_mat)
     # update the quantum state
     unitary_time_evol_gate.update_quantum_state(current_q_state)
     # I need to sample something here and return a bitstring
-    state_obtained=current_q_state.sampling(sampling_count=1)[0]
-    state_obtained_binary=f"{state_obtained:0{num_spins}b}"
+    state_obtained = current_q_state.sampling(sampling_count=1)[0]
+    state_obtained_binary = f"{state_obtained:0{num_spins}b}"
     return state_obtained_binary
 
 
-def create_X_mixer_hamiltonian(num_spins:int,weight_individual_pauli:int):
-    mixer_hamiltonian=Observable(num_spins)
-    print("type_mixer_hamiltonian:",type(mixer_hamiltonian))
-    num_sumterms=num_spins-weight_individual_pauli+1
-    list_individual_terms=[("X %d "*weight_individual_pauli) % tuple(range(i,i+weight_individual_pauli)) for i in range(0,num_sumterms)]
+def create_X_mixer_hamiltonian(num_spins: int, weight_individual_pauli: int):
+    mixer_hamiltonian = Observable(num_spins)
+    print("type_mixer_hamiltonian:", type(mixer_hamiltonian))
+    num_sumterms = num_spins - weight_individual_pauli + 1
+    list_individual_terms = [
+        ("X %d " * weight_individual_pauli)
+        % tuple(range(i, i + weight_individual_pauli))
+        for i in range(0, num_sumterms)
+    ]
     print("list_individual_terms:")
     print(list_individual_terms)
-    for i in range(0,num_sumterms):
-        mixer_hamiltonian.add_operator(coef=1,string=list_individual_terms[i])
+    for i in range(0, num_sumterms):
+        mixer_hamiltonian.add_operator(coef=1, string=list_individual_terms[i])
     return mixer_hamiltonian
+
 
 def quantum_mcmc_exact(
     n_hops: int,
     model: IsingEnergyFunction,
     H_mix: Observable,
     initial_state: Optional[str] = None,
-    gamma_range:tuple=(0.2,0.6),# we will be varying this
+    gamma_range: tuple = (0.2, 0.6),  # we will be varying this
     temperature=1,
-    verbose:bool= False
+    verbose: bool = False,
 ):
     """
     version 0.2
-    
+
     ARGS:
     ----
     Nhops: Number of time you want to run mcmc
@@ -89,7 +101,7 @@ def quantum_mcmc_exact(
 
     RETURNS:
     -------
-    mcmc chain. 
+    mcmc chain.
     """
     num_spins = model.num_spins
 
@@ -97,47 +109,59 @@ def quantum_mcmc_exact(
         initial_state = MCMCState(get_random_state(num_spins), accepted=True)
     else:
         initial_state = MCMCState(initial_state, accepted=True)
-    
+
     current_state: MCMCState = initial_state
-    #instantiate a QuantumState object for current_state: current_quantum_state
-    current_quantum_state=QuantumState(num_spins)
-    current_quantum_state.set_computational_basis(int(current_state.bitstring,2))
+    # instantiate a QuantumState object for current_state: current_quantum_state
+    current_quantum_state = QuantumState(num_spins)
+    current_quantum_state.set_computational_basis(int(current_state.bitstring, 2))
 
     energy_s = model.get_energy(current_state.bitstring)
-    if verbose: print("starting with: ", current_state.bitstring, "with energy:", energy_s)
+    if verbose:
+        print("starting with: ", current_state.bitstring, "with energy:", energy_s)
     mcmc_chain = MCMCChain([current_state])
 
-    alpha=model.alpha
-    H_prob_obj=model.get_hamiltonian()
-    H_prob_array=H_prob_obj.get_matrix().toarray()
-    H_mixer_array=H_mix.get_matrix().toarray()
-    
-    #if I keep gamma fixed
-    #gamma=0.5#float(np.round(np.random.uniform(low= min(gamma_range), high = max(gamma_range) ), decimals=6))
-    #hamiltonian_mcmc=(1-gamma)*alpha*(-1)*H_prob_array + gamma * H_mixer_array #this needs to come here.
-    
-    for _ in tqdm(range(0, n_hops), desc='runnning quantum MCMC steps . ..', disable= not verbose ):
-        gamma=float(np.round(np.random.uniform(low= min(gamma_range), high = max(gamma_range) ), decimals=6))
-        hamiltonian_mcmc=(1-gamma)*alpha*(-1)*H_prob_array + gamma * H_mixer_array #this needs to come here.
-        time_evol=int(np.random.choice(list(range(2,12))))
+    alpha = model.alpha
+    H_prob_obj = model.get_hamiltonian()
+    H_prob_array = H_prob_obj.get_matrix().toarray()
+    H_mixer_array = H_mix.get_matrix().toarray()
+
+    # if I keep gamma fixed
+    # gamma=0.5#float(np.round(np.random.uniform(low= min(gamma_range), high = max(gamma_range) ), decimals=6))
+    # hamiltonian_mcmc=(1-gamma)*alpha*(-1)*H_prob_array + gamma * H_mixer_array #this needs to come here.
+
+    for _ in tqdm(
+        range(0, n_hops), desc="runnning quantum MCMC steps . ..", disable=not verbose
+    ):
+        gamma = float(
+            np.round(
+                np.random.uniform(low=min(gamma_range), high=max(gamma_range)),
+                decimals=6,
+            )
+        )
+        hamiltonian_mcmc = (1 - gamma) * alpha * (
+            -1
+        ) * H_prob_array + gamma * H_mixer_array  # this needs to come here.
+        time_evol = int(np.random.choice(list(range(2, 12))))
         # get sprime
-        s_prime=time_evolution(num_spins=num_spins,
-                          hamiltonian=hamiltonian_mcmc,
-                          current_q_state=current_quantum_state,
-                          time_evol=time_evol)
-        #print("sprime is:",s_prime)
-        if len(s_prime) == model.num_spins :
+        s_prime = time_evolution(
+            num_spins=num_spins,
+            hamiltonian=hamiltonian_mcmc,
+            current_q_state=current_quantum_state,
+            time_evol=time_evol,
+        )
+        # print("sprime is:",s_prime)
+        if len(s_prime) == model.num_spins:
             # accept/reject s_prime
             energy_sprime = model.get_energy(s_prime)
-            accepted = test_accept(
-                energy_s, energy_sprime, temperature=temperature
-            )
+            accepted = test_accept(energy_s, energy_sprime, temperature=temperature)
             mcmc_chain.add_state(MCMCState(s_prime, accepted))
             if accepted:
                 current_state = mcmc_chain.current_state
-                #re-instantiate current state QuantumState object
-                current_quantum_state=QuantumState(num_spins)
-                current_quantum_state.set_computational_basis(int(current_state.bitstring,2))
+                # re-instantiate current state QuantumState object
+                current_quantum_state = QuantumState(num_spins)
+                current_quantum_state.set_computational_basis(
+                    int(current_state.bitstring, 2)
+                )
                 energy_s = model.get_energy(current_state.bitstring)
-        #print("s_current is:",current_state.bitstring)
-    return mcmc_chain 
+        # print("s_current is:",current_state.bitstring)
+    return mcmc_chain

--- a/qumcmc/training.py
+++ b/qumcmc/training.py
@@ -96,7 +96,7 @@ def cd_h(
 
 
 # @dataclass
-class cd_training:
+class CDTraining:
     """
     model: initial model = (J init, h init) at some temp T
     beta: 1/Temperature

--- a/qumcmc/training.py
+++ b/qumcmc/training.py
@@ -20,7 +20,6 @@ from .mcmc_sampler_base import MCMCSampler, QuantumMCMCSampler, ClassicalMCMCSam
 # from .quantum_mcmc_routines import  quantum_enhanced_mcmc  # for qulacs Simulator backend
 
 
-
 # from .quantum_mcmc_routines_qulacs import quantum_enhanced_mcmc   #for qiskit Aer's Simulator backend
 # from .trajectory_processing import (
 #     calculate_running_kl_divergence,
@@ -165,40 +164,19 @@ class CDTraining:
         save_gradient_info=False,
     ):  # we will try to increase mcmc steps.
 
-        # method = mcmc_settings["mcmc_type"]
-        # mixer = mcmc_settings["mixer"]
-
         # random.seed(random.random()) ## add seed to random ##TODO
-        initial_state = self.data_distribution.get_sample(1)[0]  ##randomly select a state from the data distribution
+        initial_state = self.data_distribution.get_sample(1)[
+            0
+        ]  ##randomly select a state from the data distribution
         mcmc_sampler.n_hops = mcmc_steps
         mcmc_sampler.initial_state = initial_state
-                
-        self.mcmc_chain = mcmc_sampler.run()
-        # if isinstance(mcmc_sampler, qumcmc_sampler):
-        # # if method == "quantum-enhanced":
-        #     # self.mcmc_chain = quantum_enhanced_mcmc(
-        #     #     n_hops=mcmc_steps,
-        #     #     name=method,
-        #     #     model=self.model,
-        #     #     initial_state=initialise_chain,
-        #     #     temperature=1 / self.model_beta,
-        #     #     mixer=mixer,
-        #     #     verbose=False,
-        #     # )
 
-        
-        # elif isinstance(mcmc_sampler, clmcmc_sampler):
-        # # elif method == "classical":
-        #     self.mcmc_chain = classical_mcmc(
-        #         n_hops=mcmc_steps,
-        #         name=method,
-        #         model=self.model,
-        #         initial_state=initialise_chain,
-        #         temperature=1 / self.model_beta,
-        #         proposition_method=mixer,
-        #         verbose=False,
-        #     )
-        max_grad_h =0 ; max_grad_J =0; min_grad_h=0 ; min_grad_J=0
+        self.mcmc_chain = mcmc_sampler.run()
+
+        max_grad_h = 0
+        max_grad_J = 0
+        min_grad_h = 0
+        min_grad_J = 0
         if update_strategy[0] == "random":  ## random update strategy ##
 
             ## just realised that even this is not a good thing!
@@ -213,8 +191,6 @@ class CDTraining:
             list_random_indices = random.sample(
                 range(0, self.model.num_spins), update_strategy[1]["num_random_bias"]
             )
-            # list_pair_of_indices=[[i,j] for i in range(1,self.model.num_spins) for j in range(i,self.model.num_spins) if j!=i]
-            # list_pair_of_different_indices=random.sample(self.list_pair_of_indices,k=update_strategy[1]['num_random_interactions'])
 
             list_pair_of_different_indices = [
                 [
@@ -304,7 +280,7 @@ class CDTraining:
 
     def train(
         self,
-        mcmc_sampler : Union[ClassicalMCMCSampler, QuantumMCMCSampler],
+        mcmc_sampler: Union[ClassicalMCMCSampler, QuantumMCMCSampler],
         mcmc_steps: int = 500,
         lr: float = 0.01,
         # mcmc_settings={"mcmc_type": "quantum-enhanced", "mixer": [[["random", 1]], []]},
@@ -341,7 +317,7 @@ class CDTraining:
         for epoch in iterator:
 
             self._train_on_mcmc_chain(
-                mcmc_sampler= mcmc_sampler,
+                mcmc_sampler=mcmc_sampler,
                 lr=lr,
                 mcmc_steps=mcmc_steps,
                 update_strategy=update_strategy,

--- a/qumcmc/training.py
+++ b/qumcmc/training.py
@@ -14,8 +14,12 @@ import random
 from .basic_utils import *
 from .prob_dist import DiscreteProbabilityDistribution, kl_divergence, vectoried_KL
 from .energy_models import IsingEnergyFunction, Exact_Sampling, random_ising_model
-from .classical_mcmc_routines import clmcmc_sampler, classical_mcmc
-from .quantum_mcmc_routines import qumcmc_sampler, quantum_enhanced_mcmc  # for qulacs Simulator backend
+from .mcmc_sampler_base import MCMCSampler, QuantumMCMCSampler, ClassicalMCMCSampler
+
+# from .classical_mcmc_routines import classical_mcmc
+# from .quantum_mcmc_routines import  quantum_enhanced_mcmc  # for qulacs Simulator backend
+
+
 
 # from .quantum_mcmc_routines_qulacs import quantum_enhanced_mcmc   #for qiskit Aer's Simulator backend
 # from .trajectory_processing import (
@@ -154,7 +158,7 @@ class CDTraining:
 
     def _train_on_mcmc_chain(
         self,
-        mcmc_sampler: Union[clmcmc_sampler, qumcmc_sampler],
+        mcmc_sampler: Union[ClassicalMCMCSampler, QuantumMCMCSampler],
         lr: float = 0.01,
         mcmc_steps: int = 1000,
         update_strategy=["all", []],
@@ -300,7 +304,7 @@ class CDTraining:
 
     def train(
         self,
-        mcmc_sampler : Union[clmcmc_sampler, qumcmc_sampler],
+        mcmc_sampler : Union[ClassicalMCMCSampler, QuantumMCMCSampler],
         mcmc_steps: int = 500,
         lr: float = 0.01,
         # mcmc_settings={"mcmc_type": "quantum-enhanced", "mixer": [[["random", 1]], []]},

--- a/qumcmc/trajectory_processing.py
+++ b/qumcmc/trajectory_processing.py
@@ -1,62 +1,67 @@
 from .prob_dist import *
 from .energy_models import IsingEnergyFunction, Exact_Sampling
 
+
 class trajectory_processing:
-    '''  
-    A class to use list_of_samples for different calculations 
-    
+    """
+    A class to use list_of_samples for different calculations
+
     Method given here (but not limited to) can
     be come in handy for calculations of interest.
-    '''
-    def __init__(self, list_of_samples_sampled:list):
-        self.list_samples=list_of_samples_sampled
-        self.num_mcmc_steps= len(list_of_samples_sampled)
-        self.num_spins=len(list_of_samples_sampled[0])
-        self.all_poss_samples=states(num_spins=len(list_of_samples_sampled[0]))
+    """
+
+    def __init__(self, list_of_samples_sampled: list):
+        self.list_samples = list_of_samples_sampled
+        self.num_mcmc_steps = len(list_of_samples_sampled)
+        self.num_spins = len(list_of_samples_sampled[0])
+        self.all_poss_samples = states(num_spins=len(list_of_samples_sampled[0]))
         # import states function from basic utils.py
         # from qumcmc.prob_dist import *
-        self.dict_count=self.count_states_occurence(list_samples= self.list_samples)
-        self.dict_distn=self.empirical_distn()# not efficient! that is why I dont want inplace replacement
-    
-    def count_states_occurence(self,list_samples)->DiscreteProbabilityDistribution:
-        ''' 
+        self.dict_count = self.count_states_occurence(list_samples=self.list_samples)
+        self.dict_distn = (
+            self.empirical_distn()
+        )  # not efficient! that is why I dont want inplace replacement
+
+    def count_states_occurence(self, list_samples) -> DiscreteProbabilityDistribution:
+        """
         Function to get dict of occurence count of sample
 
         Returns: instance of DiscreteProbabilityDistrubution
-        '''
-        dict_count=DiscreteProbabilityDistribution(
-            dict(zip(self.all_poss_samples,[0]*(len(self.all_poss_samples))))
+        """
+        dict_count = DiscreteProbabilityDistribution(
+            dict(zip(self.all_poss_samples, [0] * (len(self.all_poss_samples))))
         )
         dict_count.update(dict(Counter(list_samples)))
         return dict_count
-    
-    def empirical_distn(self)->DiscreteProbabilityDistribution:
-        ''' 
+
+    def empirical_distn(self) -> DiscreteProbabilityDistribution:
+        """
         Function to get dict of empirical distn from list of samples M.Chain was in.
 
         Returns: an instance of DiscreteProbabilityDistrubution
-        '''
-        dict_distn=DiscreteProbabilityDistribution(
-            dict(zip(self.all_poss_samples,[0]*(len(self.all_poss_samples))))
+        """
+        dict_distn = DiscreteProbabilityDistribution(
+            dict(zip(self.all_poss_samples, [0] * (len(self.all_poss_samples))))
         )
-        update_with=DiscreteProbabilityDistribution(dict(Counter(self.list_samples)))
+        update_with = DiscreteProbabilityDistribution(dict(Counter(self.list_samples)))
         update_with._normalise()
         dict_distn.update(update_with)
         return dict_distn
-    
-    def running_avg_magnetization_as_list(self)->np.array:
+
+    def running_avg_magnetization_as_list(self) -> np.array:
         """
         Function to calculate the running average magnetization for the given mcmc trajectory as list
-        
+
         Args:
         list_states_mcmc= List of state markov chain is in after each MCMC step
-        
+
         Returns: numpy array of running value of magnetization
 
         """
         list_of_strings = self.list_samples
         list_of_lists = (
-            np.array([list(int(s) for s in bitstring) for bitstring in list_of_strings]) * 2
+            np.array([list(int(s) for s in bitstring) for bitstring in list_of_strings])
+            * 2
             - 1
         )
         return np.array(
@@ -66,43 +71,59 @@ class trajectory_processing:
             ]
         )
 
-    def average_of_some_observable(self,dict_observable_val_at_states: dict):
-        return avg(dict_probabilities=self.dict_distn, dict_observable_val_at_states=dict_observable_val_at_states)
-    
-    def running_js_divergence(self, actual_boltz_distn:DiscreteProbabilityDistribution):
-       
+    def average_of_some_observable(self, dict_observable_val_at_states: dict):
+        return avg(
+            dict_probabilities=self.dict_distn,
+            dict_observable_val_at_states=dict_observable_val_at_states,
+        )
+
+    def running_js_divergence(
+        self, actual_boltz_distn: DiscreteProbabilityDistribution
+    ):
+
         list_chain_state_accepted = self.list_samples
-        num_nhops=len(list_chain_state_accepted)
-        list_js_after_each_step=[]
-        possible_states=list(actual_boltz_distn.keys())
-        time_sec1=[];time_sec2=[]
-        num_spins=len(list_chain_state_accepted[0])
-        poss_states=states(num_spins=num_spins) 
-        for step_num in tqdm(range(100,num_nhops, 100)): ##pafloxy : starting at 100 instead of 0 , neglecting intital states m.chain was in
+        num_nhops = len(list_chain_state_accepted)
+        list_js_after_each_step = []
+        possible_states = list(actual_boltz_distn.keys())
+        time_sec1 = []
+        time_sec2 = []
+        num_spins = len(list_chain_state_accepted[0])
+        poss_states = states(num_spins=num_spins)
+        for step_num in tqdm(
+            range(100, num_nhops, 100)
+        ):  ##pafloxy : starting at 100 instead of 0 , neglecting intital states m.chain was in
 
-            temp_distn_model=dict(zip(possible_states,[0]*(len(possible_states))))
+            temp_distn_model = dict(zip(possible_states, [0] * (len(possible_states))))
 
-            temp_distn_model.update(get_distn(list_chain_state_accepted[50:step_num]))  ##pafloxy : starting from 50, neglecting inital state m.chain was in 
+            temp_distn_model.update(
+                get_distn(list_chain_state_accepted[50:step_num])
+            )  ##pafloxy : starting from 50, neglecting inital state m.chain was in
 
-            js_temp=js_divergence(actual_boltz_distn,temp_distn_model)
+            js_temp = js_divergence(actual_boltz_distn, temp_distn_model)
 
             list_js_after_each_step.append(js_temp)
 
-
         return list_js_after_each_step
+
 
 ##############################################################################################
 ## Functions to process trajectory data from MCMChain instances ##
 ##############################################################################################
 
-def calculate_running_kl_divergence(actual_boltz_distn: DiscreteProbabilityDistribution, mcmc_chain: MCMCChain, skip_steps: int = 1, verbose= False) -> list:
+
+def calculate_running_kl_divergence(
+    actual_boltz_distn: DiscreteProbabilityDistribution,
+    mcmc_chain: MCMCChain,
+    skip_steps: int = 1,
+    verbose=False,
+) -> list:
     if skip_steps > 1:
         print("skip_steps currently not available and defaults to 1")
-    
+
         # TODO
         num_nhops = len(mcmc_chain.states)
-    
-    list_kl_after_each_step=[]
+
+    list_kl_after_each_step = []
 
     ## slow
     # for step_num in tqdm(range(1, num_nhops, skip_steps), disable= not verbose): ##pafloxy : starting at 100 instead of 0 , neglecting effect of intital states
@@ -119,329 +140,442 @@ def calculate_running_kl_divergence(actual_boltz_distn: DiscreteProbabilityDistr
     nspin = len(list(actual_boltz_distn.keys())[0])
     mod_probs = np.zeros(2**nspin)
 
-    for ii, bitstr in tqdm(enumerate(mcmc_chain.markov_chain, start=1), disable= not verbose): 
-        
+    for ii, bitstr in tqdm(
+        enumerate(mcmc_chain.markov_chain, start=1), disable=not verbose
+    ):
+
         mod_probs[int(bitstr, 2)] += 1
 
-        kl_temp = vectoried_KL(tar_probs, mod_probs/ii)
+        kl_temp = vectoried_KL(tar_probs, mod_probs / ii)
 
         list_kl_after_each_step.append(kl_temp)
 
     return list_kl_after_each_step
 
 
-def calculate_running_js_divergence(actual_boltz_distn: DiscreteProbabilityDistribution, mcmc_chain: MCMCChain, skip_steps: int = 1,prelim_check=False) -> list:
+def calculate_running_js_divergence(
+    actual_boltz_distn: DiscreteProbabilityDistribution,
+    mcmc_chain: MCMCChain,
+    skip_steps: int = 1,
+    prelim_check=False,
+) -> list:
     num_nhops = len(mcmc_chain.states)
-    
-    list_js_after_each_step=[]
 
-    for step_num in tqdm(range(1, num_nhops, skip_steps)): ##pafloxy : starting at 100 instead of 0 , neglecting effect of intital states
+    list_js_after_each_step = []
 
-        temp_distn_model = mcmc_chain.get_accepted_dict(normalize=True, until_index=step_num)
+    for step_num in tqdm(
+        range(1, num_nhops, skip_steps)
+    ):  ##pafloxy : starting at 100 instead of 0 , neglecting effect of intital states
 
-        js_temp=js_divergence(actual_boltz_distn,temp_distn_model, prelim_check= prelim_check)
+        temp_distn_model = mcmc_chain.get_accepted_dict(
+            normalize=True, until_index=step_num
+        )
+
+        js_temp = js_divergence(
+            actual_boltz_distn, temp_distn_model, prelim_check=prelim_check
+        )
 
         list_js_after_each_step.append(js_temp)
 
-
     return list_js_after_each_step
 
-def calculate_runnning_magnetisation(mcmc_chain: MCMCChain, skip_steps: int = 1, verbose:bool= False) -> list:    
-    
+
+def calculate_runnning_magnetisation(
+    mcmc_chain: MCMCChain, skip_steps: int = 1, verbose: bool = False
+) -> list:
+
     num_nhops = len(mcmc_chain.states)
 
-    list_mag_after_each_step=[]    
+    list_mag_after_each_step = []
 
-    magnetisation_dict = dict([ (state, magnetization_of_state(state) ) for state  in  mcmc_chain.accepted_states ])
+    magnetisation_dict = dict(
+        [(state, magnetization_of_state(state)) for state in mcmc_chain.accepted_states]
+    )
 
-    for step_num in tqdm(range(1, num_nhops, skip_steps), disable= not verbose): ##pafloxy : starting at 100 instead of 0 , neglecting effect of intital states
+    for step_num in tqdm(
+        range(1, num_nhops, skip_steps), disable=not verbose
+    ):  ##pafloxy : starting at 100 instead of 0 , neglecting effect of intital states
 
-        temp_distn_model = DiscreteProbabilityDistribution( mcmc_chain.get_accepted_dict(normalize=True, until_index=step_num) )
-        
+        temp_distn_model = DiscreteProbabilityDistribution(
+            mcmc_chain.get_accepted_dict(normalize=True, until_index=step_num)
+        )
+
         mag_temp = temp_distn_model.expectation(magnetisation_dict)
 
         list_mag_after_each_step.append(mag_temp)
-    
+
     return list_mag_after_each_step
 
-from typing import Union        
-def get_trajectory_statistics(mcmc_chain: MCMCChain, model: Union[IsingEnergyFunction, Exact_Sampling],
-                                to_observe:set = {'acceptance_prob','kldiv', 'hamming', 'energy', 'magnetisation'} 
-                                ,verbose:bool= False):
+
+from typing import Union
+
+
+def get_trajectory_statistics(
+    mcmc_chain: MCMCChain,
+    model: Union[IsingEnergyFunction, Exact_Sampling],
+    to_observe: set = {
+        "acceptance_prob",
+        "kldiv",
+        "hamming",
+        "energy",
+        "magnetisation",
+    },
+    verbose: bool = False,
+):
 
     trajectory = mcmc_chain.states
 
     # acceptance_prob = lambda si, sf: min(1, model.get_boltzmann_factor(sf.bitstring) / model.get_boltzmann_factor(si.bitstring) )
     hamming_diff = lambda si, sf: hamming_dist(si.bitstring, sf.bitstring)
-    energy_diff = lambda si, sf: model.get_energy(sf.bitstring) - model.get_energy(si.bitstring)
+    energy_diff = lambda si, sf: model.get_energy(sf.bitstring) - model.get_energy(
+        si.bitstring
+    )
 
-    acceptance_statistic = [];hamming_statistic = [];energy_statistic = []
-    
-    current_state_index = 0; proposed_state_index = current_state_index + 1
+    acceptance_statistic = []
+    hamming_statistic = []
+    energy_statistic = []
 
-    while proposed_state_index < len(trajectory) :
+    current_state_index = 0
+    proposed_state_index = current_state_index + 1
 
-        
-        if verbose : print('trans: '+ str(trajectory[current_state_index].bitstring) + ' -> '+ str(trajectory[proposed_state_index].bitstring)+" status: "+str(trajectory[proposed_state_index].accepted)  )
+    while proposed_state_index < len(trajectory):
+
+        if verbose:
+            print(
+                "trans: "
+                + str(trajectory[current_state_index].bitstring)
+                + " -> "
+                + str(trajectory[proposed_state_index].bitstring)
+                + " status: "
+                + str(trajectory[proposed_state_index].accepted)
+            )
 
         # if 'acceptance_prob' in to_observe: acceptance_statistic.append( acceptance_prob(trajectory[current_state_index], trajectory[proposed_state_index] ) )
-        if 'energy' in to_observe: energy_statistic.append( energy_diff(trajectory[current_state_index], trajectory[proposed_state_index] ) )
-        #if 'hamming' in to_observe: hamming_statistic.append( hamming_diff(trajectory[current_state_index], trajectory[proposed_state_index] ) )
+        if "energy" in to_observe:
+            energy_statistic.append(
+                energy_diff(
+                    trajectory[current_state_index], trajectory[proposed_state_index]
+                )
+            )
+        # if 'hamming' in to_observe: hamming_statistic.append( hamming_diff(trajectory[current_state_index], trajectory[proposed_state_index] ) )
 
-        
-        if trajectory[proposed_state_index].accepted :
-            current_state_index =  proposed_state_index
-        
+        if trajectory[proposed_state_index].accepted:
+            current_state_index = proposed_state_index
+
         proposed_state_index += 1
 
-    ### acceptance probability 
-    if 'acceptance_prob' in to_observe:
+    ### acceptance probability
+    if "acceptance_prob" in to_observe:
         current_bitstring = trajectory[0].bitstring
         counter = 1
         for st in trajectory:
-            if st.accepted and st.bitstring!=current_bitstring: # not, and, or.
-                acceptance_statistic.append(1/counter)
+            if st.accepted and st.bitstring != current_bitstring:  # not, and, or.
+                acceptance_statistic.append(1 / counter)
                 current_bitstring = st.bitstring
                 counter = 1
             else:
                 counter += 1
-        acceptance_statistic.append(1/counter)
+        acceptance_statistic.append(1 / counter)
 
     ### hamming distance caln
-    num_spins=model.num_spins
-    hamming_dist_keys=list(range(0,num_spins+1))
-    init_val_keys=dict(zip(['accepted', 'rejected', 'total'],[0,0,0]))
-    list_init_val_keys=[init_val_keys.copy() for i in range(0,len(hamming_dist_keys))]
-    dict_hamming_distance_statistics=dict(zip(hamming_dist_keys, list_init_val_keys))
-    
-    current_bs_idx=0
-    for proposed_bs_idx in range(1,len(trajectory)):
-        hamming_dist_val=hamming_diff(si=trajectory[current_bs_idx],
-                                        sf=trajectory[proposed_bs_idx])
+    num_spins = model.num_spins
+    hamming_dist_keys = list(range(0, num_spins + 1))
+    init_val_keys = dict(zip(["accepted", "rejected", "total"], [0, 0, 0]))
+    list_init_val_keys = [
+        init_val_keys.copy() for i in range(0, len(hamming_dist_keys))
+    ]
+    dict_hamming_distance_statistics = dict(zip(hamming_dist_keys, list_init_val_keys))
+
+    current_bs_idx = 0
+    for proposed_bs_idx in range(1, len(trajectory)):
+        hamming_dist_val = hamming_diff(
+            si=trajectory[current_bs_idx], sf=trajectory[proposed_bs_idx]
+        )
         if trajectory[proposed_bs_idx].accepted:
-            dict_hamming_distance_statistics[hamming_dist_val]['accepted']+=1
-            current_bs_idx=proposed_bs_idx
+            dict_hamming_distance_statistics[hamming_dist_val]["accepted"] += 1
+            current_bs_idx = proposed_bs_idx
         else:
-            dict_hamming_distance_statistics[hamming_dist_val]['rejected']+=1
-    
-    for i in range(0,num_spins+1):
-        dict_hamming_distance_statistics[i]['total']=dict_hamming_distance_statistics[i]['accepted']+dict_hamming_distance_statistics[i]['rejected']
+            dict_hamming_distance_statistics[hamming_dist_val]["rejected"] += 1
+
+    for i in range(0, num_spins + 1):
+        dict_hamming_distance_statistics[i]["total"] = (
+            dict_hamming_distance_statistics[i]["accepted"]
+            + dict_hamming_distance_statistics[i]["rejected"]
+        )
 
     trajectory_statistics = {}
-    if 'acceptance_prob' in to_observe: trajectory_statistics['acceptance_prob'] = np.array(acceptance_statistic)
-    if 'energy' in to_observe: trajectory_statistics['energy'] = np.array(energy_statistic)
-    if 'hamming' in to_observe: trajectory_statistics['hamming'] = dict_hamming_distance_statistics#np.array(hamming_statistic)
-    if 'kldiv' in to_observe:
-        rkl = calculate_running_kl_divergence(model.boltzmann_pd, mcmc_chain, skip_steps= 1)
-        trajectory_statistics['kldiv'] = np.array(rkl)
+    if "acceptance_prob" in to_observe:
+        trajectory_statistics["acceptance_prob"] = np.array(acceptance_statistic)
+    if "energy" in to_observe:
+        trajectory_statistics["energy"] = np.array(energy_statistic)
+    if "hamming" in to_observe:
+        trajectory_statistics["hamming"] = (
+            dict_hamming_distance_statistics  # np.array(hamming_statistic)
+        )
+    if "kldiv" in to_observe:
+        rkl = calculate_running_kl_divergence(
+            model.boltzmann_pd, mcmc_chain, skip_steps=1
+        )
+        trajectory_statistics["kldiv"] = np.array(rkl)
 
     return trajectory_statistics
+
 
 ##############################################################################################
 ## Class to process MCMCData from multiple experiments ##
 ##############################################################################################
 import os
 import pickle
-class ProcessMCMCData():
-    
-    
-    def __init__(self, data: dict, model: Exact_Sampling, savefile_path: str = None, name: str= 'SAMPLINGRESULT'):
+
+
+class ProcessMCMCData:
+
+    def __init__(
+        self,
+        data: dict,
+        model: Exact_Sampling,
+        savefile_path: str = None,
+        name: str = "SAMPLINGRESULT",
+    ):
 
         self.data = data
         self.model = model
         self.processed_data = {}
         self.savefile_path = savefile_path
-        self.name = name 
-        
+        self.name = name
+
         self.seeds = list(self.data.keys())
         self.mcmc_types = list(self.data[1].keys())
-        
-        # os.chdir(self.savefile_path)
-        print('OUTPUT DIRECTORY: ', os.path.join( os.getcwd(), self.savefile_path) )
-    
-    def PROCESS_ALL(self,save_data= True):
-        
-        self.CALCULATE_KL_DIV(save_data= save_data  )
-        self.CALCULATE_MAGNETISATION(save_data= save_data  )
-        self.CALCULATE_MCMC_STATISTICS(save_data= save_data  )
-        if save_data :
-            os.chdir(self.savefile_path)                
-            with open(self.name + '.pkl','wb') as f:
-                    pickle.dump(self,f)
-            os.chdir('../..')
-    
-    def UPDATE_DATA(self, new_data: dict, new_seeds, new_mcmc_types, save_data = True):
 
-        if self.processed_data == {} :
-            raise ValueError(' method ''UPDATE_DATA'' cannot be called on unprocessed data, call "PROCESS_ALL" intially ')
+        # os.chdir(self.savefile_path)
+        print("OUTPUT DIRECTORY: ", os.path.join(os.getcwd(), self.savefile_path))
+
+    def PROCESS_ALL(self, save_data=True):
+
+        self.CALCULATE_KL_DIV(save_data=save_data)
+        self.CALCULATE_MAGNETISATION(save_data=save_data)
+        self.CALCULATE_MCMC_STATISTICS(save_data=save_data)
+        if save_data:
+            os.chdir(self.savefile_path)
+            with open(self.name + ".pkl", "wb") as f:
+                pickle.dump(self, f)
+            os.chdir("../..")
+
+    def UPDATE_DATA(self, new_data: dict, new_seeds, new_mcmc_types, save_data=True):
+
+        if self.processed_data == {}:
+            raise ValueError(
+                " method "
+                "UPDATE_DATA"
+                ' cannot be called on unprocessed data, call "PROCESS_ALL" intially '
+            )
 
         self.data = new_data
-        self.CALCULATE_KL_DIV(save_data= save_data, allow_reprocessing=True, seeds_new= new_seeds, mcmc_types_new= new_mcmc_types )
-        self.CALCULATE_MAGNETISATION(save_data= save_data, allow_reprocessing=True, seeds_new= new_seeds, mcmc_types_new= new_mcmc_types )
-        self.CALCULATE_MCMC_STATISTICS(save_data= save_data, allow_reprocessing=True, seeds_new= new_seeds, mcmc_types_new= new_mcmc_types )
-        
+        self.CALCULATE_KL_DIV(
+            save_data=save_data,
+            allow_reprocessing=True,
+            seeds_new=new_seeds,
+            mcmc_types_new=new_mcmc_types,
+        )
+        self.CALCULATE_MAGNETISATION(
+            save_data=save_data,
+            allow_reprocessing=True,
+            seeds_new=new_seeds,
+            mcmc_types_new=new_mcmc_types,
+        )
+        self.CALCULATE_MCMC_STATISTICS(
+            save_data=save_data,
+            allow_reprocessing=True,
+            seeds_new=new_seeds,
+            mcmc_types_new=new_mcmc_types,
+        )
+
         self.seeds = list(self.data.keys())
         self.mcmc_types = list(self.data[1].keys())
-    
+
     # def PLOT_KL_DIV(self, save_plot = False, mcmc_types_to_plot = 'all'):
-    
+
     #     ## plotting
     #     x=list(range(0,15000+1))
     #     plt.figure(figsize=(12,8))
-    #     if mcmc_types_to_plot == 'all': 
+    #     if mcmc_types_to_plot == 'all':
     #         mcmc_types_to_plot = self.processed_data['KL-DIV'].keys()
     #     for mcmc_type in mcmc_types_to_plot:
     #         plot_with_error_band(x, self.processed_data['KL-DIV'][mcmc_type] ,label= mcmc_type)
-    
+
     #     plt.xlabel("iterations ")
     #     plt.ylabel("KL divergence")
     #     plt.yscale('log')
     #     plt.legend()
 
     #     if save_plot:
-    #             os.chdir(self.savefile_path)      
+    #             os.chdir(self.savefile_path)
     #             figname = self.name + 'KL-DIV.pdf'
     #             plt.savefig(figname)
-        
-    #             os.chdir('../..')        
-        
+
+    #             os.chdir('../..')
+
     #     plt.show()
 
-    def CALCULATE_KL_DIV(self, save_data:bool= False, allow_reprocessing= False, seeds_new = None, mcmc_types_new= None  ):
-        
+    def CALCULATE_KL_DIV(
+        self,
+        save_data: bool = False,
+        allow_reprocessing=False,
+        seeds_new=None,
+        mcmc_types_new=None,
+    ):
+
         not_computed = False
-        ## data processing    
-        if 'KL-DIV' not in self.processed_data:
+        ## data processing
+        if "KL-DIV" not in self.processed_data:
             not_computed = True
             seeds = self.seeds
             mcmc_types = self.mcmc_types
-            self.processed_data['KL-DIV'] = { mcmc_type: [] for mcmc_type in self.mcmc_types }
+            self.processed_data["KL-DIV"] = {
+                mcmc_type: [] for mcmc_type in self.mcmc_types
+            }
 
         if allow_reprocessing:
-            if seeds_new == None: seeds = self.seeds
-            else: seeds = seeds_new
-            
-            if mcmc_types_new == None: mcmc_types = self.mcmc_types 
-            else: 
+            if seeds_new == None:
+                seeds = self.seeds
+            else:
+                seeds = seeds_new
+
+            if mcmc_types_new == None:
+                mcmc_types = self.mcmc_types
+            else:
                 mcmc_types = mcmc_types_new
                 for mcmc_type in mcmc_types:
-                    self.processed_data['KL-DIV'][mcmc_type] = []
+                    self.processed_data["KL-DIV"][mcmc_type] = []
 
         if not_computed or allow_reprocessing:
             for seed in tqdm(seeds):
                 for mcmc_type in mcmc_types:
-          
-                    kldiv = calculate_running_kl_divergence(self.model.boltzmann_pd, self.data[seed][mcmc_type])
-                    self.processed_data['KL-DIV'][mcmc_type].append(kldiv)
 
-            if save_data :
-                os.chdir(self.savefile_path)                
-                with open(self.name + '.pkl','wb') as f:
-                        pickle.dump(self,f)
-                os.chdir('../..')
+                    kldiv = calculate_running_kl_divergence(
+                        self.model.boltzmann_pd, self.data[seed][mcmc_type]
+                    )
+                    self.processed_data["KL-DIV"][mcmc_type].append(kldiv)
 
+            if save_data:
+                os.chdir(self.savefile_path)
+                with open(self.name + ".pkl", "wb") as f:
+                    pickle.dump(self, f)
+                os.chdir("../..")
 
     # def PLOT_MAGNETISATION(self, save_plot= False , mcmc_types_to_plot = 'all'):
-    
+
     #     ## plotting
     #     fig, ax1 = plt.subplots(figsize=(12,8))
     #     left, bottom, width, height = [0.55, 0.2, 0.25, 0.25]
 
     #     x=list(range(0,15000))
     #     # mcmc_types = self.data[1].keys()
-    #     if mcmc_types_to_plot == 'all': 
+    #     if mcmc_types_to_plot == 'all':
     #         mcmc_types_to_plot = self.processed_data['MAGNETISATION'].keys()
-        
+
     #     for mcmc_type in mcmc_types_to_plot:
-            
+
     #         mean_mag_local=np.mean(self.processed_data['MAGNETISATION'][mcmc_type],axis=0)
     #         std_local=np.std(self.processed_data['MAGNETISATION'][mcmc_type],axis=0)
     #         ax1.plot(x,mean_mag_local,label= mcmc_type)
     #         ax1.fill_between(x,mean_mag_local-std_local/2,mean_mag_local+std_local/2,alpha=0.45)
 
-
     #     ax1.axhline(self.model.get_observable_expectation(magnetization_of_state), label= 'actual',linestyle='--')
     #     ax1.legend()
     #     ax1.set_xlabel("Iterations")
     #     ax1.set_ylabel("Magnetisation")
-        
-    #     if save_plot:       
-    #             os.chdir(self.savefile_path)         
+
+    #     if save_plot:
+    #             os.chdir(self.savefile_path)
     #             figname = self.name + 'MAGNETISATION.pdf'
     #             plt.savefig(figname)
-    #             os.chdir('../..')        
-            
+    #             os.chdir('../..')
+
     #     plt.show()
 
-    def CALCULATE_MAGNETISATION(self, save_data:bool = False , allow_reprocessing= False, seeds_new = None, mcmc_types_new= None  ):
-        
+    def CALCULATE_MAGNETISATION(
+        self,
+        save_data: bool = False,
+        allow_reprocessing=False,
+        seeds_new=None,
+        mcmc_types_new=None,
+    ):
+
         not_computed = False
         ## data processing
-        if 'MAGNETISATION' not in self.processed_data:
+        if "MAGNETISATION" not in self.processed_data:
             not_computed = True
             seeds = self.seeds
             mcmc_types = self.mcmc_types
-            self.processed_data['MAGNETISATION'] = { mcmc_type: [] for mcmc_type in mcmc_types }
-            magnetization_model = self.model.get_observable_expectation(magnetization_of_state)
+            self.processed_data["MAGNETISATION"] = {
+                mcmc_type: [] for mcmc_type in mcmc_types
+            }
+            magnetization_model = self.model.get_observable_expectation(
+                magnetization_of_state
+            )
 
         if allow_reprocessing:
-            if seeds_new == None: seeds = self.seeds
-            else: seeds = seeds_new
-            
-            if mcmc_types_new == None: mcmc_types = self.mcmc_types 
-            else: 
+            if seeds_new == None:
+                seeds = self.seeds
+            else:
+                seeds = seeds_new
+
+            if mcmc_types_new == None:
+                mcmc_types = self.mcmc_types
+            else:
                 mcmc_types = mcmc_types_new
                 for mcmc_type in mcmc_types:
-                    self.processed_data['MAGNETISATION'][mcmc_type] = []
-
+                    self.processed_data["MAGNETISATION"][mcmc_type] = []
 
         if not_computed or allow_reprocessing:
-        
+
             for seed in tqdm(seeds):
                 for mcmc_type in mcmc_types:
-                    mag = calculate_runnning_magnetisation(self.data[seed][mcmc_type], verbose= False)
-                    self.processed_data['MAGNETISATION'][mcmc_type].append(mag)
+                    mag = calculate_runnning_magnetisation(
+                        self.data[seed][mcmc_type], verbose=False
+                    )
+                    self.processed_data["MAGNETISATION"][mcmc_type].append(mag)
 
-
-            if save_data :
+            if save_data:
                 os.chdir(self.savefile_path)
-                
-                with open(self.name + '.pkl','wb') as f:
-                        pickle.dump(self,f)
-                os.chdir('../..') 
+
+                with open(self.name + ".pkl", "wb") as f:
+                    pickle.dump(self, f)
+                os.chdir("../..")
 
     # def PLOT_MCMC_STATISTICS(self,  save_plot= True, mcmc_types_to_plot = 'all' , statistic_to_plot:str= 'acceptance_prob'):
-    
+
     #     ## plotting
     #     plt.figure(1,figsize=(20,15))
-        
-    #     if mcmc_types_to_plot == 'all': 
+
+    #     if mcmc_types_to_plot == 'all':
     #         mcmc_types_to_plot = self.processed_data['MAGNETISATION'].keys()
 
     #     dim1 = int(len(self.data.keys()) / 2); dim2 = 2
     #     for seed in tqdm(self.seeds):
     #         for mcmc_type in mcmc_types_to_plot:
-    #             stat_to_plot = self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][statistic_to_plot] 
-                
+    #             stat_to_plot = self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][statistic_to_plot]
+
     #             plt.subplot(dim1,dim2,seed)
 
     #             if statistic_to_plot == 'acceptance_prob':
     #                 plt.hist(np.log10(stat_to_plot),
-    #                     label= mcmc_type ,alpha= 0.5, 
+    #                     label= mcmc_type ,alpha= 0.5,
     #                     bins= 50,density=True)
-                    
+
     #                 if seed==9 or seed==10:
     #                     plt.xlabel("log(Acceptance Rate)")
-    #             else : 
+    #             else :
     #                 plt.hist(stat_to_plot,
-    #                     label= mcmc_type ,alpha= 0.1, 
+    #                     label= mcmc_type ,alpha= 0.1,
     #                     bins= 50,density=True)
-                    
+
     #                 if seed==9 or seed==10:
     #                     plt.xlabel(statistic_to_plot)
-        
+
     #         plt.legend()
-            
+
     #     if save_plot:
     #         os.chdir(self.savefile_path)
     #         figname  = self.name + 'ACCEPTANCEPROB.pdf'
@@ -449,380 +583,565 @@ class ProcessMCMCData():
     #         os.chdir('../..')
 
     #         plt.show()
-        
-    def CALCULATE_MCMC_STATISTICS(self, save_data: bool = False, allow_reprocessing= False, seeds_new = None, mcmc_types_new= None ):
+
+    def CALCULATE_MCMC_STATISTICS(
+        self,
+        save_data: bool = False,
+        allow_reprocessing=False,
+        seeds_new=None,
+        mcmc_types_new=None,
+    ):
 
         not_computed = False
-        ## data processing ##        
-        if 'MCMC-STATISTICS' not in self.processed_data:
+        ## data processing ##
+        if "MCMC-STATISTICS" not in self.processed_data:
             not_computed = True
             seeds = self.seeds
             mcmc_types = self.mcmc_types
-            self.processed_data['MCMC-STATISTICS'] = { seed: {} for seed in seeds }
-        
-        if allow_reprocessing :
-            if seeds_new == None: seeds = self.seeds
-            else: 
+            self.processed_data["MCMC-STATISTICS"] = {seed: {} for seed in seeds}
+
+        if allow_reprocessing:
+            if seeds_new == None:
+                seeds = self.seeds
+            else:
                 seeds = seeds_new
                 for seed in seeds:
-                    self.processed_data['MCMC-STATISTICS'][seed] = {}
-            
-            if mcmc_types_new == None: mcmc_types = self.mcmc_types 
-            else: mcmc_types = mcmc_types_new
-        
-        if not_computed or allow_reprocessing :
-            
-            for seed in tqdm(seeds, desc= "Processing MCMC Statistics"):
+                    self.processed_data["MCMC-STATISTICS"][seed] = {}
+
+            if mcmc_types_new == None:
+                mcmc_types = self.mcmc_types
+            else:
+                mcmc_types = mcmc_types_new
+
+        if not_computed or allow_reprocessing:
+
+            for seed in tqdm(seeds, desc="Processing MCMC Statistics"):
                 for mcmc_type in mcmc_types:
-                    self.processed_data['MCMC-STATISTICS'][seed][mcmc_type] = {}
-                    stat_data = get_trajectory_statistics(self.data[seed][mcmc_type], self.model)
+                    self.processed_data["MCMC-STATISTICS"][seed][mcmc_type] = {}
+                    stat_data = get_trajectory_statistics(
+                        self.data[seed][mcmc_type], self.model
+                    )
                     for stat in stat_data.keys():
-                        self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][stat] = stat_data[stat]
-            
+                        self.processed_data["MCMC-STATISTICS"][seed][mcmc_type][
+                            stat
+                        ] = stat_data[stat]
+
             if save_data:
                 os.chdir(self.savefile_path)
 
-                with open(self.name + '.pkl', 'wb') as f:
+                with open(self.name + ".pkl", "wb") as f:
                     pickle.dump(self, f)
-                
-                os.chdir('../..')
+
+                os.chdir("../..")
 
 
 ## HELPER FUNCTIONS ###
 
-def PLOT_MCMC_STATISTICS(self: ProcessMCMCData,  save_plot= False, mcmc_types_to_plot = 'all' , statistic_to_plot:str= 'acceptance_prob', kwargs_hamming = {'type': ['total', 'accepted'], 'width': 0.13}, kwargs_acceptance_prob= {'histtype':'stepfilled', 'stacked': True, 'density': True}):
-    
-        ## plotting
-        plt.figure(1,figsize=(20,15))
-        
-        if mcmc_types_to_plot == 'all': 
-            mcmc_types_to_plot = list(self.processed_data['MAGNETISATION'].keys())
 
-        dim1 = int(len(self.data.keys()) / 2); dim2 = 2
-        
-        
-        if statistic_to_plot == 'acceptance_prob':
-            mcmc_labels = [mcmc_type for mcmc_type in mcmc_types_to_plot]
-            pos =1
-            for seed in tqdm(self.seeds):    
-                
-                    # stat_to_plot = [ np.log10( self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][statistic_to_plot] ) for mcmc_type in mcmc_types_to_plot]
-                    
-                    plt.subplot(dim1,dim2,pos) ; pos += 1
+def PLOT_MCMC_STATISTICS(
+    self: ProcessMCMCData,
+    save_plot=False,
+    mcmc_types_to_plot="all",
+    statistic_to_plot: str = "acceptance_prob",
+    kwargs_hamming={"type": ["total", "accepted"], "width": 0.13},
+    kwargs_acceptance_prob={"histtype": "stepfilled", "stacked": True, "density": True},
+):
 
-                    # for mcmc_label in mcmc_labels:
-                    #     stat_to_plot = np.log10( self.processed_data['MCMC-STATISTICS'][seed][mcmc_label][statistic_to_plot] )
-                    #     x, bins, p = plt.hist(stat_to_plot,
-                    #         label= mcmc_label ,alpha= 0.5, 
-                    #         bins= np.linspace(-5,0,50), density= kwargs_acceptance_prob['density'],  histtype= kwargs_acceptance_prob['histtype'])
-                    #     # print(sum(x))
-                    #     # for item in p:
-                    #             # item.set_height(item.get_height()/sum(x))
-                    #     # print(p)
-                    
-                    max_ht = 0
-                    for mcmc_label in mcmc_labels:
-                        stat_to_plot = np.log10( self.processed_data['MCMC-STATISTICS'][seed][mcmc_label][statistic_to_plot] )
-                        heights, bins = np.histogram(stat_to_plot, bins= np.linspace(-5,0,75) , density= True,)
-                        heights = heights/sum(heights)
-                        bin_centers = 0.5*(bins[1:] + bins[:-1])
-                        bin_widths = np.diff(bins)
-                        
-                        plt.bar(bin_centers, heights, width=bin_widths, alpha=0.5, label = mcmc_label)    
+    ## plotting
+    plt.figure(1, figsize=(20, 15))
 
-                        if max(heights) > max_ht :
-                             max_ht = max(heights)
+    if mcmc_types_to_plot == "all":
+        mcmc_types_to_plot = list(self.processed_data["MAGNETISATION"].keys())
 
-                    if seed==9 or seed==10:
-                        plt.xlabel("log(Acceptance Rate)")
-                    
-                    lgnd = plt.legend(loc='upper left', ncols= 4)
-            
-                    plt.ylim((0, max_ht + 0.05 ))        
-            plt.show()        
-                
-        elif statistic_to_plot == 'hamming':
-            mcmc_labels = [mcmc_type for mcmc_type in mcmc_types_to_plot]
-            pos = 1
-            for seed in tqdm(self.seeds):
-                
-                ticks = list(self.processed_data['MCMC-STATISTICS'][seed][mcmc_types_to_plot[0]][statistic_to_plot].keys())
-                
-            
-                plt.subplot(dim1,dim2,pos) ; pos += 1
+    dim1 = int(len(self.data.keys()) / 2)
+    dim2 = 2
 
-                width = kwargs_hamming['width']  
-                x = np.arange(len(ticks))
+    if statistic_to_plot == "acceptance_prob":
+        mcmc_labels = [mcmc_type for mcmc_type in mcmc_types_to_plot]
+        pos = 1
+        for seed in tqdm(self.seeds):
 
-                if 'total' in kwargs_hamming['type']:        
-                    multiplier = 0            
-                    for mcmc_type in mcmc_labels :
-                        offset = width * multiplier
-                        values_1 = [self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][statistic_to_plot][key]['total'] for key in ticks ]
-                        rects = plt.bar(x + offset, values_1, width, label= mcmc_type, alpha = 0.5, edgecolor = 'k')
-                        # plt.bar_label(rects, padding=3)
-                        multiplier += 1
-                
-                if 'accepted' in kwargs_hamming['type']:
-                    multiplier = 0            
-                    for mcmc_type in mcmc_labels :
-                        offset = width * multiplier
-                        values_2 = [self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][statistic_to_plot][key]['accepted'] for key in ticks ]
-                        if 'total' in kwargs_hamming['type']: rects = plt.bar(x + offset, values_2, width, alpha = 1.0, fill= False, edgecolor = 'k', hatch= '///')
-                        else : rects = plt.bar(x + offset, values_2, width, alpha = 0.5, edgecolor = 'k', label= mcmc_type)
-                        # plt.bar_label(rects, padding=3)
-                        multiplier += 1
-        
-         
-                plt.xticks(x + width, ticks)    
-                if seed==9 or seed==10:
-                    plt.xlabel(statistic_to_plot)
-                
-                lgnd = plt.legend(loc='upper left', ncols= len(mcmc_labels))
-            plt.show()
-                # print(lgnd.get_han())
-        else :
-            for seed in tqdm(self.seeds):        
-                    plt.subplot(dim1,dim2,seed)
+            # stat_to_plot = [ np.log10( self.processed_data['MCMC-STATISTICS'][seed][mcmc_type][statistic_to_plot] ) for mcmc_type in mcmc_types_to_plot]
 
-                    plt.hist(stat_to_plot,
-                        label= mcmc_type ,alpha= 0.1, 
-                        bins= 50,density=True)
-                    
-                    if seed==9 or seed==10:
-                        plt.xlabel(statistic_to_plot)
-            
-            plt.legend(loc='upper left', ncols=3)
-            
-        
-            
-        if save_plot:
-            os.chdir(self.savefile_path)
-            figname  = self.name + '_' + statistic_to_plot
-            plt.savefig(figname)
-            os.chdir('../..')
+            plt.subplot(dim1, dim2, pos)
+            pos += 1
 
-        
-            
-def PLOT_MAGNETISATION(self: ProcessMCMCData, save_plot= False , mcmc_types_to_plot = 'all'):
-    
-        ## plotting
-        fig, ax1 = plt.subplots(figsize=(26,16))
-        left, bottom, width, height = [0.55, 0.2, 0.25, 0.25]
+            # for mcmc_label in mcmc_labels:
+            #     stat_to_plot = np.log10( self.processed_data['MCMC-STATISTICS'][seed][mcmc_label][statistic_to_plot] )
+            #     x, bins, p = plt.hist(stat_to_plot,
+            #         label= mcmc_label ,alpha= 0.5,
+            #         bins= np.linspace(-5,0,50), density= kwargs_acceptance_prob['density'],  histtype= kwargs_acceptance_prob['histtype'])
+            #     # print(sum(x))
+            #     # for item in p:
+            #             # item.set_height(item.get_height()/sum(x))
+            #     # print(p)
 
-        anc0 = list(self.data.keys())[0]
-        anc1 = list(self.data[anc0].keys())[0]
-        dim0 = len(self.data[anc0][anc1].markov_chain)
-        x=list(range(0,dim0-1))
-        # mcmc_types = self.data[1].keys()
-        if mcmc_types_to_plot == 'all': 
-            mcmc_types_to_plot = self.processed_data['MAGNETISATION'].keys()
-        
-        for mcmc_type in mcmc_types_to_plot:
-            
-            mean_mag_local=np.mean(self.processed_data['MAGNETISATION'][mcmc_type],axis=0)
-            std_local=np.std(self.processed_data['MAGNETISATION'][mcmc_type],axis=0)
-            ax1.plot(x,mean_mag_local,label= mcmc_type)
-            ax1.fill_between(x,mean_mag_local-std_local/2,mean_mag_local+std_local/2,alpha=0.45)
+            max_ht = 0
+            for mcmc_label in mcmc_labels:
+                stat_to_plot = np.log10(
+                    self.processed_data["MCMC-STATISTICS"][seed][mcmc_label][
+                        statistic_to_plot
+                    ]
+                )
+                heights, bins = np.histogram(
+                    stat_to_plot,
+                    bins=np.linspace(-5, 0, 75),
+                    density=True,
+                )
+                heights = heights / sum(heights)
+                bin_centers = 0.5 * (bins[1:] + bins[:-1])
+                bin_widths = np.diff(bins)
 
+                plt.bar(
+                    bin_centers, heights, width=bin_widths, alpha=0.5, label=mcmc_label
+                )
 
-        ax1.axhline(self.model.get_observable_expectation(magnetization_of_state), label= 'actual',linestyle='--')
-        ax1.legend()
-        ax1.set_xlabel("Iterations")
-        ax1.set_ylabel("Magnetisation")
-        
-        if save_plot:       
-                os.chdir(self.savefile_path)         
-                figname = self.name + 'MAGNETISATION.pdf'
-                plt.savefig(figname)
-                os.chdir('../..')        
-            
+                if max(heights) > max_ht:
+                    max_ht = max(heights)
+
+            if seed == 9 or seed == 10:
+                plt.xlabel("log(Acceptance Rate)")
+
+            lgnd = plt.legend(loc="upper left", ncols=4)
+
+            plt.ylim((0, max_ht + 0.05))
         plt.show()
 
-def PLOT_KL_DIV(self:ProcessMCMCData , save_plot = False, mcmc_types_to_plot = 'all'):
-    
-        ## plotting
-        anc0 = list(self.data.keys())[0]
-        anc1 = list(self.data[anc0].keys())[0]
-        dim0 = len(self.data[anc0][anc1].markov_chain)
-        x=list(range(0,dim0))
-        plt.figure(figsize=(12,8))
-        if mcmc_types_to_plot == 'all': 
-            mcmc_types_to_plot = self.processed_data['KL-DIV'].keys()
-        for mcmc_type in mcmc_types_to_plot:
-            plot_with_error_band(x, self.processed_data['KL-DIV'][mcmc_type] ,label= mcmc_type)
-    
-        plt.xlabel("iterations ")
-        plt.ylabel("KL divergence")
-        plt.yscale('log')
-        plt.legend()
+    elif statistic_to_plot == "hamming":
+        mcmc_labels = [mcmc_type for mcmc_type in mcmc_types_to_plot]
+        pos = 1
+        for seed in tqdm(self.seeds):
 
-        if save_plot:
-                os.chdir(self.savefile_path)      
-                figname = self.name + 'KL-DIV.pdf'
-                plt.savefig(figname)
-        
-                os.chdir('../..')        
-        
+            ticks = list(
+                self.processed_data["MCMC-STATISTICS"][seed][mcmc_types_to_plot[0]][
+                    statistic_to_plot
+                ].keys()
+            )
+
+            plt.subplot(dim1, dim2, pos)
+            pos += 1
+
+            width = kwargs_hamming["width"]
+            x = np.arange(len(ticks))
+
+            if "total" in kwargs_hamming["type"]:
+                multiplier = 0
+                for mcmc_type in mcmc_labels:
+                    offset = width * multiplier
+                    values_1 = [
+                        self.processed_data["MCMC-STATISTICS"][seed][mcmc_type][
+                            statistic_to_plot
+                        ][key]["total"]
+                        for key in ticks
+                    ]
+                    rects = plt.bar(
+                        x + offset,
+                        values_1,
+                        width,
+                        label=mcmc_type,
+                        alpha=0.5,
+                        edgecolor="k",
+                    )
+                    # plt.bar_label(rects, padding=3)
+                    multiplier += 1
+
+            if "accepted" in kwargs_hamming["type"]:
+                multiplier = 0
+                for mcmc_type in mcmc_labels:
+                    offset = width * multiplier
+                    values_2 = [
+                        self.processed_data["MCMC-STATISTICS"][seed][mcmc_type][
+                            statistic_to_plot
+                        ][key]["accepted"]
+                        for key in ticks
+                    ]
+                    if "total" in kwargs_hamming["type"]:
+                        rects = plt.bar(
+                            x + offset,
+                            values_2,
+                            width,
+                            alpha=1.0,
+                            fill=False,
+                            edgecolor="k",
+                            hatch="///",
+                        )
+                    else:
+                        rects = plt.bar(
+                            x + offset,
+                            values_2,
+                            width,
+                            alpha=0.5,
+                            edgecolor="k",
+                            label=mcmc_type,
+                        )
+                    # plt.bar_label(rects, padding=3)
+                    multiplier += 1
+
+            plt.xticks(x + width, ticks)
+            if seed == 9 or seed == 10:
+                plt.xlabel(statistic_to_plot)
+
+            lgnd = plt.legend(loc="upper left", ncols=len(mcmc_labels))
         plt.show()
+        # print(lgnd.get_han())
+    else:
+        for seed in tqdm(self.seeds):
+            plt.subplot(dim1, dim2, seed)
+
+            plt.hist(stat_to_plot, label=mcmc_type, alpha=0.1, bins=50, density=True)
+
+            if seed == 9 or seed == 10:
+                plt.xlabel(statistic_to_plot)
+
+        plt.legend(loc="upper left", ncols=3)
+
+    if save_plot:
+        os.chdir(self.savefile_path)
+        figname = self.name + "_" + statistic_to_plot
+        plt.savefig(figname)
+        os.chdir("../..")
+
+
+def PLOT_MAGNETISATION(
+    self: ProcessMCMCData, save_plot=False, mcmc_types_to_plot="all"
+):
+
+    ## plotting
+    fig, ax1 = plt.subplots(figsize=(26, 16))
+    left, bottom, width, height = [0.55, 0.2, 0.25, 0.25]
+
+    anc0 = list(self.data.keys())[0]
+    anc1 = list(self.data[anc0].keys())[0]
+    dim0 = len(self.data[anc0][anc1].markov_chain)
+    x = list(range(0, dim0 - 1))
+    # mcmc_types = self.data[1].keys()
+    if mcmc_types_to_plot == "all":
+        mcmc_types_to_plot = self.processed_data["MAGNETISATION"].keys()
+
+    for mcmc_type in mcmc_types_to_plot:
+
+        mean_mag_local = np.mean(
+            self.processed_data["MAGNETISATION"][mcmc_type], axis=0
+        )
+        std_local = np.std(self.processed_data["MAGNETISATION"][mcmc_type], axis=0)
+        ax1.plot(x, mean_mag_local, label=mcmc_type)
+        ax1.fill_between(
+            x,
+            mean_mag_local - std_local / 2,
+            mean_mag_local + std_local / 2,
+            alpha=0.45,
+        )
+
+    ax1.axhline(
+        self.model.get_observable_expectation(magnetization_of_state),
+        label="actual",
+        linestyle="--",
+    )
+    ax1.legend()
+    ax1.set_xlabel("Iterations")
+    ax1.set_ylabel("Magnetisation")
+
+    if save_plot:
+        os.chdir(self.savefile_path)
+        figname = self.name + "MAGNETISATION.pdf"
+        plt.savefig(figname)
+        os.chdir("../..")
+
+    plt.show()
+
+
+def PLOT_KL_DIV(self: ProcessMCMCData, save_plot=False, mcmc_types_to_plot="all"):
+
+    ## plotting
+    anc0 = list(self.data.keys())[0]
+    anc1 = list(self.data[anc0].keys())[0]
+    dim0 = len(self.data[anc0][anc1].markov_chain)
+    x = list(range(0, dim0))
+    plt.figure(figsize=(12, 8))
+    if mcmc_types_to_plot == "all":
+        mcmc_types_to_plot = self.processed_data["KL-DIV"].keys()
+    for mcmc_type in mcmc_types_to_plot:
+        plot_with_error_band(
+            x, self.processed_data["KL-DIV"][mcmc_type], label=mcmc_type
+        )
+
+    plt.xlabel("iterations ")
+    plt.ylabel("KL divergence")
+    plt.yscale("log")
+    plt.legend()
+
+    if save_plot:
+        os.chdir(self.savefile_path)
+        figname = self.name + "KL-DIV.pdf"
+        plt.savefig(figname)
+
+        os.chdir("../..")
+
+    plt.show()
+
 
 ############################## Updates 01/11/23 ########
 ########################################################
 
-def Reshuffle(data, type= 'gamma', MCMCTYPES=None, GAMMATYPES= None, dtypes =  ['KL-DIV', 'MAGNETISATION'] ):
-    if type == 'gamma':    
+
+def Reshuffle(
+    data,
+    type="gamma",
+    MCMCTYPES=None,
+    GAMMATYPES=None,
+    dtypes=["KL-DIV", "MAGNETISATION"],
+):
+    if type == "gamma":
         # MCMCTYPES = data['p'].mcmc_types
-        RESULT_shuffled = { mcmc_types : { dtype : {} for dtype in dtypes  } for mcmc_types in MCMCTYPES}
+        RESULT_shuffled = {
+            mcmc_types: {dtype: {} for dtype in dtypes} for mcmc_types in MCMCTYPES
+        }
         for mcmc_type in MCMCTYPES:
             for dtype in dtypes:
                 for gamma_type in GAMMATYPES:
-                    RESULT_shuffled[mcmc_type][dtype][gamma_type] = data[gamma_type].processed_data[dtype][mcmc_type] 
-            
-            RESULT_shuffled[mcmc_type]['MCMC-STATISTICS'] = { _ : {} for _ in data[gamma_type].processed_data['MCMC-STATISTICS'].keys()}
+                    RESULT_shuffled[mcmc_type][dtype][gamma_type] = data[
+                        gamma_type
+                    ].processed_data[dtype][mcmc_type]
+
+            RESULT_shuffled[mcmc_type]["MCMC-STATISTICS"] = {
+                _: {} for _ in data[gamma_type].processed_data["MCMC-STATISTICS"].keys()
+            }
             for gamma_type in GAMMATYPES:
-                for _ in data[gamma_type].processed_data['MCMC-STATISTICS'].keys() :
-                    RESULT_shuffled[mcmc_type]['MCMC-STATISTICS'][_][gamma_type] = data[gamma_type].processed_data['MCMC-STATISTICS'][_][mcmc_type]
-                    
-                 
-        
-    
-    if type == 'mcmc_type':    
+                for _ in data[gamma_type].processed_data["MCMC-STATISTICS"].keys():
+                    RESULT_shuffled[mcmc_type]["MCMC-STATISTICS"][_][gamma_type] = data[
+                        gamma_type
+                    ].processed_data["MCMC-STATISTICS"][_][mcmc_type]
+
+    if type == "mcmc_type":
         # MCMCTYPES = data['p'].mcmc_types
-        RESULT_shuffled = { gamma_types : { dtype : {} for dtype in dtypes  } for gamma_types in GAMMATYPES}
+        RESULT_shuffled = {
+            gamma_types: {dtype: {} for dtype in dtypes} for gamma_types in GAMMATYPES
+        }
         for gamma_type in GAMMATYPES:
-            for dtype in ['KL-DIV', 'MAGNETISATION']:
-                for mcmc_type in MCMCTYPES:        
-                    RESULT_shuffled[gamma_type][dtype][mcmc_type] = data[gamma_type].processed_data[dtype][mcmc_type] 
-                
-                RESULT_shuffled[gamma_type]['MCMC-STATISTICS'] = data[gamma_type].processed_data['MCMC-STATISTICS']
+            for dtype in ["KL-DIV", "MAGNETISATION"]:
+                for mcmc_type in MCMCTYPES:
+                    RESULT_shuffled[gamma_type][dtype][mcmc_type] = data[
+                        gamma_type
+                    ].processed_data[dtype][mcmc_type]
+
+                RESULT_shuffled[gamma_type]["MCMC-STATISTICS"] = data[
+                    gamma_type
+                ].processed_data["MCMC-STATISTICS"]
 
     # if type == 'mcmc_statistics':
 
-        
     return RESULT_shuffled
 
-class EXPERIMENTRESULTS():
 
-    def __init__(self, exp_results:dict, type:str, model: Exact_Sampling, mcmc_types, gamma_ranges, savefile_path: str = None, name: str= 'SAMPLINGRESULT') -> None:
-        
-        self.exp_result = Reshuffle(exp_results,type= type, MCMCTYPES= mcmc_types, GAMMATYPES= gamma_ranges)
+class EXPERIMENTRESULTS:
+
+    def __init__(
+        self,
+        exp_results: dict,
+        type: str,
+        model: Exact_Sampling,
+        mcmc_types,
+        gamma_ranges,
+        savefile_path: str = None,
+        name: str = "SAMPLINGRESULT",
+    ) -> None:
+
+        self.exp_result = Reshuffle(
+            exp_results, type=type, MCMCTYPES=mcmc_types, GAMMATYPES=gamma_ranges
+        )
         self.mcmc_types = mcmc_types
         self.gamma_ranges = gamma_ranges
         self.model = model
-        if type == 'gamma': 
+        if type == "gamma":
             self.upper_types = self.mcmc_types
             self.lower_types = self.gamma_ranges
-        elif type == 'mcmc_type':
+        elif type == "mcmc_type":
             self.upper_types = self.gamma_ranges
             self.lower_types = self.mcmc_types
-        
-def PLOT_MCMC_STATISTICS_HAMMING(data, figsize, kwargs_hamming = {'type': ['total', 'accepted'], 'width': 0.13} ):
 
-    for uptype in data.upper_types :
-        print ( 'Type : ' + uptype )    
 
-        plt.figure(figsize=(20,15))
-        labels = list(data.exp_result[uptype]['MCMC-STATISTICS'].keys())
-        dim1 = int(np.ceil(len(labels)/2)); dim2 = 2; pos = 1
+def PLOT_MCMC_STATISTICS_HAMMING(
+    data, figsize, kwargs_hamming={"type": ["total", "accepted"], "width": 0.13}
+):
 
-        for seed in tqdm( data.exp_result[uptype]['MCMC-STATISTICS'].keys() ):
-            
-            plt.subplot(dim1,dim2,pos) ; pos += 1
-            width = kwargs_hamming['width']  
-            
-            if 'total' in kwargs_hamming['type']:        
-                multiplier = 0            
-                for type in data.lower_types :
-                    ticks = list(data.exp_result[uptype]['MCMC-STATISTICS'][seed][type]['hamming'].keys()); x = np.arange(len(ticks))
-                    offset = width * multiplier
-                    values_1 = [data.exp_result[uptype]['MCMC-STATISTICS'][seed][type]['hamming'][key]['total'] for key in ticks ]
-                    rects = plt.bar(x + offset, values_1, width, label= type, alpha = 0.5, edgecolor = 'k')
-                    # plt.bar_label(rects, padding=3)
-                    multiplier += 1
-            
-            if 'accepted' in kwargs_hamming['type']:
-                multiplier = 0            
-                for type in data.lower_types :
-                    ticks = list(data.exp_result[uptype]['MCMC-STATISTICS'][seed][type]['hamming'].keys()); x = np.arange(len(ticks))
-                    offset = width * multiplier
-                    values_2 = [data.exp_result[uptype]['MCMC-STATISTICS'][seed][type]['hamming'][key]['accepted'] for key in ticks ]
-                    if 'total' in kwargs_hamming['type']: rects = plt.bar(x + offset, values_2, width, alpha = 1.0, fill= False, edgecolor = 'k', hatch= '///')
-                    else : rects = plt.bar(x + offset, values_2, width, alpha = 0.5, edgecolor = 'k', label= type)
-                    # plt.bar_label(rects, padding=3)
-                    multiplier += 1
+    for uptype in data.upper_types:
+        print("Type : " + uptype)
 
-        
-            plt.xticks(x + width, ticks)    
-            if seed==9 or seed==10:
-                plt.xlabel('hamming')
-            
-            lgnd = plt.legend(loc='upper left', ncols= len(labels))
-        plt.show()
-
-def PLOT_KL_DIV_NEW(data , figsize=(26,16), save_plot = False,):
-    
-        ## plotting
-        plt.figure(figsize=figsize)
-        dim1 = int(np.ceil(len(data.upper_types)/2)) ; dim2 = 2 
+        plt.figure(figsize=(20, 15))
+        labels = list(data.exp_result[uptype]["MCMC-STATISTICS"].keys())
+        dim1 = int(np.ceil(len(labels) / 2))
+        dim2 = 2
         pos = 1
 
-        for uptype in data.upper_types :
-            plt.subplot(dim1, dim2, pos) ; pos += 1
-            for lotype in data.lower_types :
-                x= list(range(0, len(data.exp_result[uptype]['KL-DIV'][lotype][0])))
-                plot_with_error_band(x, data.exp_result[uptype]['KL-DIV'][lotype] ,label= lotype)
-        
-            plt.xlabel("iterations ")
-            plt.ylabel("KL divergence")
-            plt.yscale('log')
-            plt.legend()
-            plt.title(uptype)
-        
-        # plt.suptitle('KL-Div ')
-        # if save_plot:
-        #         os.chdir(data.savefile_path)      
-        #         figname = data.name + 'KL-DIV.pdf'
-        #         plt.savefig(figname)
-        
-        #         os.chdir('../..')        
-        
+        for seed in tqdm(data.exp_result[uptype]["MCMC-STATISTICS"].keys()):
+
+            plt.subplot(dim1, dim2, pos)
+            pos += 1
+            width = kwargs_hamming["width"]
+
+            if "total" in kwargs_hamming["type"]:
+                multiplier = 0
+                for type in data.lower_types:
+                    ticks = list(
+                        data.exp_result[uptype]["MCMC-STATISTICS"][seed][type][
+                            "hamming"
+                        ].keys()
+                    )
+                    x = np.arange(len(ticks))
+                    offset = width * multiplier
+                    values_1 = [
+                        data.exp_result[uptype]["MCMC-STATISTICS"][seed][type][
+                            "hamming"
+                        ][key]["total"]
+                        for key in ticks
+                    ]
+                    rects = plt.bar(
+                        x + offset,
+                        values_1,
+                        width,
+                        label=type,
+                        alpha=0.5,
+                        edgecolor="k",
+                    )
+                    # plt.bar_label(rects, padding=3)
+                    multiplier += 1
+
+            if "accepted" in kwargs_hamming["type"]:
+                multiplier = 0
+                for type in data.lower_types:
+                    ticks = list(
+                        data.exp_result[uptype]["MCMC-STATISTICS"][seed][type][
+                            "hamming"
+                        ].keys()
+                    )
+                    x = np.arange(len(ticks))
+                    offset = width * multiplier
+                    values_2 = [
+                        data.exp_result[uptype]["MCMC-STATISTICS"][seed][type][
+                            "hamming"
+                        ][key]["accepted"]
+                        for key in ticks
+                    ]
+                    if "total" in kwargs_hamming["type"]:
+                        rects = plt.bar(
+                            x + offset,
+                            values_2,
+                            width,
+                            alpha=1.0,
+                            fill=False,
+                            edgecolor="k",
+                            hatch="///",
+                        )
+                    else:
+                        rects = plt.bar(
+                            x + offset,
+                            values_2,
+                            width,
+                            alpha=0.5,
+                            edgecolor="k",
+                            label=type,
+                        )
+                    # plt.bar_label(rects, padding=3)
+                    multiplier += 1
+
+            plt.xticks(x + width, ticks)
+            if seed == 9 or seed == 10:
+                plt.xlabel("hamming")
+
+            lgnd = plt.legend(loc="upper left", ncols=len(labels))
         plt.show()
 
-def PLOT_MAGNETISATION_NEW(data , figsize=(26,16), save_plot = False,):
-    
-        ## plotting
-        plt.figure(figsize= figsize)
-        dim1 = int(np.ceil(len(data.upper_types)/2)) ; dim2 = 2 ; pos = 1
-        # left, bottom, width, height = [0.55, 0.2, 0.25, 0.25]
 
-        # anc0 = list(self.data.keys())[0]
-        # anc1 = list(self.data[anc0].keys())[0]
-        # dim0 = len(self.data[anc0][anc1].markov_chain)
-        # x=list(range(0,dim0-1))
-        # mcmc_types = self.data[1].keys()
+def PLOT_KL_DIV_NEW(
+    data,
+    figsize=(26, 16),
+    save_plot=False,
+):
 
-        for uptype in data.upper_types :
-            plt.subplot(dim1, dim2, pos); pos += 1
-            # fig, ax1 = plt.subplots()
-            for lotype in data.lower_types :
-                mean_mag_local=np.mean(data.exp_result[uptype]['MAGNETISATION'][lotype],axis=0)
-                x = range(0, len(mean_mag_local))
-                std_local=np.std(data.exp_result[uptype]['MAGNETISATION'][lotype],axis=0)
-                plt.plot(x,mean_mag_local,label= lotype)
-                plt.fill_between(x,mean_mag_local-std_local/2,mean_mag_local+std_local/2,alpha=0.45)
+    ## plotting
+    plt.figure(figsize=figsize)
+    dim1 = int(np.ceil(len(data.upper_types) / 2))
+    dim2 = 2
+    pos = 1
+
+    for uptype in data.upper_types:
+        plt.subplot(dim1, dim2, pos)
+        pos += 1
+        for lotype in data.lower_types:
+            x = list(range(0, len(data.exp_result[uptype]["KL-DIV"][lotype][0])))
+            plot_with_error_band(
+                x, data.exp_result[uptype]["KL-DIV"][lotype], label=lotype
+            )
+
+        plt.xlabel("iterations ")
+        plt.ylabel("KL divergence")
+        plt.yscale("log")
+        plt.legend()
+        plt.title(uptype)
+
+    # plt.suptitle('KL-Div ')
+    # if save_plot:
+    #         os.chdir(data.savefile_path)
+    #         figname = data.name + 'KL-DIV.pdf'
+    #         plt.savefig(figname)
+
+    #         os.chdir('../..')
+
+    plt.show()
 
 
-            plt.axhline(data.model.get_observable_expectation(magnetization_of_state), label= 'actual',linestyle='--')
-            plt.legend()
-            plt.title(uptype)
-            plt.xlabel("Iterations")
-            plt.ylabel("Magnetisation")
-        plt.suptitle('')
-        
-        # if save_plot:       
-        #         os.chdir(self.savefile_path)         
-        #         figname = self.name + 'MAGNETISATION.pdf'
-        #         plt.savefig(figname)
-        #         os.chdir('../..')        
-            
-        plt.show()
+def PLOT_MAGNETISATION_NEW(
+    data,
+    figsize=(26, 16),
+    save_plot=False,
+):
+
+    ## plotting
+    plt.figure(figsize=figsize)
+    dim1 = int(np.ceil(len(data.upper_types) / 2))
+    dim2 = 2
+    pos = 1
+    # left, bottom, width, height = [0.55, 0.2, 0.25, 0.25]
+
+    # anc0 = list(self.data.keys())[0]
+    # anc1 = list(self.data[anc0].keys())[0]
+    # dim0 = len(self.data[anc0][anc1].markov_chain)
+    # x=list(range(0,dim0-1))
+    # mcmc_types = self.data[1].keys()
+
+    for uptype in data.upper_types:
+        plt.subplot(dim1, dim2, pos)
+        pos += 1
+        # fig, ax1 = plt.subplots()
+        for lotype in data.lower_types:
+            mean_mag_local = np.mean(
+                data.exp_result[uptype]["MAGNETISATION"][lotype], axis=0
+            )
+            x = range(0, len(mean_mag_local))
+            std_local = np.std(data.exp_result[uptype]["MAGNETISATION"][lotype], axis=0)
+            plt.plot(x, mean_mag_local, label=lotype)
+            plt.fill_between(
+                x,
+                mean_mag_local - std_local / 2,
+                mean_mag_local + std_local / 2,
+                alpha=0.45,
+            )
+
+        plt.axhline(
+            data.model.get_observable_expectation(magnetization_of_state),
+            label="actual",
+            linestyle="--",
+        )
+        plt.legend()
+        plt.title(uptype)
+        plt.xlabel("Iterations")
+        plt.ylabel("Magnetisation")
+    plt.suptitle("")
+
+    # if save_plot:
+    #         os.chdir(self.savefile_path)
+    #         figname = self.name + 'MAGNETISATION.pdf'
+    #         plt.savefig(figname)
+    #         os.chdir('../..')
+
+    plt.show()

--- a/testing.py
+++ b/testing.py
@@ -4,14 +4,15 @@ import qumcmc
 from qumcmc.basic_utils import *
 from qumcmc.energy_models import IsingEnergyFunction, Exact_Sampling
 
-from qumcmc.classical_mcmc_routines import classical_mcmc, clmcmc_sampler
-from qumcmc.quantum_mcmc_routines import quantum_enhanced_mcmc, qumcmc_sampler # Manuel's code
+from qumcmc.classical_mcmc_routines import classical_mcmc 
+from qumcmc.quantum_mcmc_routines import quantum_enhanced_mcmc # Manuel's code
 # from qumcmc.trajectory_processing import calculate_running_js_divergence, calculate_running_kl_divergence, calculate_runnning_magnetisation, get_trajectory_statistics
 from qumcmc.prob_dist import DiscreteProbabilityDistribution
 ### let's check if the new code is even working as desired or not
 from qumcmc.mixers import * #,GenericMixer, CustomMixer, CoherentMixerSum, IncoherentMixerSum
 from qumcmc.classical_mixers import *
-from qumcmc.training import cd_training
+from qumcmc.training import CDTraining
+from qumcmc.mcmc_sampler_base import MCMCSampler, QuantumMCMCSampler, ClassicalMCMCSampler
 ######################################################################################
 gridsize=3
 
@@ -83,7 +84,7 @@ cmxrs = [unfrm_clmixer, fxdwt_clmixer, cstm_clmixer, combined_clmixer]
 
 random_model = IsingEnergyFunction(np.random.randn(n_spins, n_spins), np.random.randn(n_spins), name = f'RandomModel|N={n_spins}' )
 
-training_inst = cd_training(random_model, 1.0, bpd_2, name = "Train")
+training_inst = CDTraining(random_model, 1.0, bpd_2, name = "Train")
 
 # training_inst.train()
 
@@ -96,7 +97,7 @@ training_inst = cd_training(random_model, 1.0, bpd_2, name = "Train")
 # print("--------------------------- \n")
 for mxr in qmxrs :
     print(f"testing {mxr} ------------")     
-    quantum_mcmc = qumcmc_sampler(10, model, mxr, 0.5, initial_state=initial_state, verbose= True)
+    quantum_mcmc = QuantumMCMCSampler(10, model, mxr, 0.5, initial_state=initial_state, verbose= True)
     quantum_mcmc.run()
     print(f" MCMC run : OK ------------")     
     quantum_mcmc.verbose = False 
@@ -106,7 +107,7 @@ for mxr in qmxrs :
 print("--------------------------- \n")
 for mxr in cmxrs : 
     print(f"testing {mxr} ------------")     
-    clmcmc = clmcmc_sampler(10, model, mxr, initial_state=initial_state, verbose= True)
+    clmcmc = ClassicalMCMCSampler(10, model, mxr, initial_state=initial_state, verbose= True)
     clmcmc.run()
     print(f" MCMC run : OK ------------")   
     clmcmc.verbose = False   

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,118 @@
+import qumcmc
+# from qumcmc.classical_mcmc_routines import *
+## import essential modules 
+from qumcmc.basic_utils import *
+from qumcmc.energy_models import IsingEnergyFunction, Exact_Sampling
+
+from qumcmc.classical_mcmc_routines import classical_mcmc, clmcmc_sampler
+from qumcmc.quantum_mcmc_routines import quantum_enhanced_mcmc, qumcmc_sampler # Manuel's code
+# from qumcmc.trajectory_processing import calculate_running_js_divergence, calculate_running_kl_divergence, calculate_runnning_magnetisation, get_trajectory_statistics
+from qumcmc.prob_dist import DiscreteProbabilityDistribution
+### let's check if the new code is even working as desired or not
+from qumcmc.mixers import * #,GenericMixer, CustomMixer, CoherentMixerSum, IncoherentMixerSum
+from qumcmc.classical_mixers import *
+from qumcmc.training import cd_training
+######################################################################################
+gridsize=3
+
+bas= bas_dataset(grid_size=gridsize)
+bas.dataset.sort()
+# consider only the bars dataset and create the weight matrix for them and create the ising model
+wt= hebbing_learning(bas.bas_dict["bars"]+ bas.bas_dict["stripes"])## added 2 datapoints from stripes dataset into it
+n_spins=gridsize*gridsize
+shape_of_J=(n_spins,n_spins)
+J=-1*wt
+h=np.zeros(n_spins)
+model=IsingEnergyFunction(J,h,name=f'ising model BAS {n_spins}X{n_spins} bars + stripes')
+
+# model.model_summary()
+beta=1.5
+## run exact sampling over all possible configurations 
+exact_sampled_model = Exact_Sampling(model, beta)
+
+## get distribution from the model
+bpd_2= DiscreteProbabilityDistribution(exact_sampled_model.boltzmann_pd)
+exact_sampled_model.sampling_summary()
+#######################################################################################
+
+
+
+num_chains=10
+steps =10000 # 30000
+gamma_range=(0.4,0.6)
+
+initial_state="111000111"
+
+
+### Creating the mixers we need
+
+generic_mixer = GenericMixer.OneBodyMixer(n_spins)
+custom_mixer_stripes = CustomMixer(n_spins,[[0,3,6],[1,4,7],[2,5,8]])
+custom_mixer_bars =  CustomMixer(n_spins,[[0, 1, 2], [3, 4, 5], [6, 7, 8]] )
+
+custom_mixer_BAS = CustomMixer(n_spins,[[0, 1, 2], [3, 4, 5], [6, 7, 8], [0,3,6] , [1,4,7] , [2,5,8]] )
+
+coherent_mixer_only_bars = CoherentMixerSum([generic_mixer, custom_mixer_bars], 
+                                            weights=[0.75, 0.25])
+coherent_mixer_with_BAS_info = CoherentMixerSum([generic_mixer, custom_mixer_bars, custom_mixer_stripes],
+                                                weights=[0.7,0.15,0.15])
+
+coherent_mixer_BAS = lambda p : CoherentMixerSum([generic_mixer, custom_mixer_BAS], weights= [1-p, p] )
+incoherent_mixer_BAS = lambda p : IncoherentMixerSum([generic_mixer, custom_mixer_BAS], probabilities= [1-p, p] )
+
+
+
+incoherent_mixer_only_bars = IncoherentMixerSum([generic_mixer, custom_mixer_bars],
+                                                probabilities=[0.75, 0.25])
+incoherent_mixer_with_BAS_info = IncoherentMixerSum([generic_mixer, custom_mixer_bars, 
+                                                    custom_mixer_stripes],
+                                                probabilities=[0.7,0.15,0.15])
+
+
+unfrm_clmixer= UniformProposals(n_spins)
+fxdwt_clmixer= FixedWeightProposals(n_spins, 4)
+cstm_clmixer= CustomProposals(n_spins, flip_pattern= [0,2,3,6])
+
+combined_clmixer= CombineProposals([unfrm_clmixer, fxdwt_clmixer, cstm_clmixer], probabilities= [0.6,0.1,0.3])
+
+
+######################################################################################### 
+
+qmxrs = [generic_mixer, custom_mixer_bars, custom_mixer_BAS, coherent_mixer_only_bars, coherent_mixer_with_BAS_info, incoherent_mixer_only_bars, incoherent_mixer_with_BAS_info]
+cmxrs = [unfrm_clmixer, fxdwt_clmixer, cstm_clmixer, combined_clmixer]
+
+random_model = IsingEnergyFunction(np.random.randn(n_spins, n_spins), np.random.randn(n_spins), name = f'RandomModel|N={n_spins}' )
+
+training_inst = cd_training(random_model, 1.0, bpd_2, name = "Train")
+
+# training_inst.train()
+
+#################################################################
+
+# for mxr in qmxrs+cmxrs : 
+#     print(mxr)
+#     print("--------------------------- \n")
+
+# print("--------------------------- \n")
+for mxr in qmxrs :
+    print(f"testing {mxr} ------------")     
+    quantum_mcmc = qumcmc_sampler(10, model, mxr, 0.5, initial_state=initial_state, verbose= True)
+    quantum_mcmc.run()
+    print(f" MCMC run : OK ------------")     
+    quantum_mcmc.verbose = False 
+    training_inst.train(quantum_mcmc, 10)
+    print(f" Training run : OK ------------")
+    # print(f"{mxr}: OK \n ----------------")
+print("--------------------------- \n")
+for mxr in cmxrs : 
+    print(f"testing {mxr} ------------")     
+    clmcmc = clmcmc_sampler(10, model, mxr, initial_state=initial_state, verbose= True)
+    clmcmc.run()
+    print(f" MCMC run : OK ------------")   
+    clmcmc.verbose = False   
+    training_inst.train(clmcmc, 10)
+    print(f" Training run : OK ------------")
+    # print(f"{mxr}: OK \n ----------------")
+
+
+################################################################# 


### PR DESCRIPTION
CHANGELOG: 

1. Addded `__repr__()` to many if the classes that we defined froweasier visualization during code-execution. 
2. Added a base class `mcmc_sampler_base` which is a decorator class using which we can access the mcmc subroutines (both quantum and classical) . Added classes inheriting from the above to quantum-mcmc module and classical-mcmc module. 
3. Refactorted training module with the previous changes. 
4. Added a `testing` script for easier checking of bugs in implementation.